### PR TITLE
chore: Next.js security patch + atomic deployment checklist

### DIFF
--- a/docs/REMAINING_WORK.md
+++ b/docs/REMAINING_WORK.md
@@ -1,0 +1,139 @@
+# Remaining Work Before Deployment
+
+Every item below is atomic — one file, one change, one test. Copilot can take any section independently.
+
+---
+
+## Section A — Security (do first)
+
+### A1 · Bump Next.js to 15.5.15 (CVE-2026-23869)
+**Status:** Done in this PR (`package.json` + `package-lock.json` already updated).
+**Verify:** `npm ci && npm run build` passes.
+
+---
+
+## Section B — Code Fixes (4 items)
+
+### B1 · Make `ALLOWED_AUDIO_MIME_TYPES` immutable
+**File:** `src/lib/server/routes/transcribe.ts`
+**Problem:** Exported as `new Set([...])` — any consumer can call `.add()` / `.delete()` and silently corrupt MIME validation globally.
+**Fix:** Change to `ReadonlySet<string>`:
+```ts
+// before
+export const ALLOWED_AUDIO_MIME_TYPES = new Set([...]);
+
+// after
+export const ALLOWED_AUDIO_MIME_TYPES: ReadonlySet<string> = new Set([...]);
+```
+**Also update:** `src/app/api/__tests__/transcribe.contract.test.ts` — import still works; iteration with `for...of` still works. No callers mutate it so no other changes needed.
+**Verify:** `npm run lint && npm run test:unit`
+
+---
+
+### B2 · Fix export checkbox accessibility
+**File:** `src/app/project/[id]/export/page.tsx`
+**Problem:** The native `<input type="checkbox">` is hidden with `sr-only` but has no `id` or `aria-labelledby` linking it to its visible label. Screen readers and keyboard users cannot identify what the checkbox controls.
+**Fix:** Add an `id` to each checkbox `<input>` and a matching `htmlFor` on the visible label element (or wrap both in a `<label>`).
+**Verify:** `npm run lint && npm run build`
+
+---
+
+### B3 · Verify `parseAiJsonObjectStrict` null branch is covered
+**File:** `src/lib/ai/__tests__/parsing.test.ts`
+**Problem:** `parseAiJsonObjectStrict` has a distinct code path when the AI returns a `null` body (not invalid JSON, but literal `null`). This path is untested; a production AI response returning `null` could surface an unhandled edge case.
+**Fix:** Add one test:
+```ts
+it('returns fallback when AI response body is null', () => {
+  const result = parseAiJsonObjectStrict(null, defaultFallback, { normalize: (v) => v });
+  assert.deepStrictEqual(result.value, defaultFallback);
+  assert.ok(result.contractIssues.length > 0);
+});
+```
+Adjust the exact API signature to match the current function signature.
+**Verify:** `npm run test:unit`
+
+---
+
+### B4 · Address remaining PR #21 review feedback (issue #31)
+**Context:** Issue #31 was auto-filed from a Copilot review of PR #21 ("Gold" listening-room UX). The feedback was marked as non-blocking at the time but was never resolved or explicitly dismissed.
+**Action:** Read issue #31 on GitHub, determine if the feedback is still applicable to current code, and either apply the fix or close the issue as `not_planned` with a comment explaining why it no longer applies.
+**File(s):** Likely in `src/app/project/[id]/record/` or `src/components/`.
+**Verify:** `npm run lint && npm run build`
+
+---
+
+## Section C — Environment Setup (must be done on the server, not in code)
+
+These cannot be committed — they must be set in the hosting platform's environment configuration.
+
+### C1 · Set `NEXTAUTH_SECRET`
+**Where:** Hosting platform env vars (Vercel: Project Settings → Environment Variables).
+**Value:** A random 32-byte hex string. Generate with: `openssl rand -hex 32`
+**Why:** NextAuth requires this to sign JWT session tokens. Without it, all sign-in attempts will fail in production.
+
+### C2 · Set `NEXTAUTH_URL`
+**Where:** Hosting platform env vars.
+**Value:** The full public URL of the deployed app, e.g. `https://yourapp.vercel.app`
+**Why:** NextAuth uses this to construct OAuth callback URLs and redirect correctly.
+
+### C3 · Set `DATABASE_URL`
+**Where:** Hosting platform env vars.
+**Value:** `file:./prod.db` for single-instance SQLite, or a connection string for a hosted database.
+**Note:** SQLite is fine for private beta on a single instance. If you plan to run more than one dyno/container, switch to PostgreSQL or PlanetScale before launch.
+
+### C4 · Set `OPENAI_API_KEY`
+**Where:** Hosting platform env vars.
+**Value:** Your OpenAI API key.
+**Note:** The app gracefully degrades (returns 400) when this is missing, so startup will succeed without it — but transcription and AI features will be unavailable.
+
+---
+
+## Section D — Deployment Operations (run once, in order)
+
+### D1 · Run database migration on production
+```bash
+DATABASE_URL=<prod-value> npx prisma db push
+```
+Do this before starting the server for the first time, or after any schema change.
+
+### D2 · Verify CI checks are set as required on `main`
+**Where:** GitHub → Repository Settings → Branches → Branch protection rules for `main`.
+**Required checks to add** (from `README.md`):
+- `CI / Quality (Node 18.x)` and `CI / Quality (Node 20.x)`
+- `CI / Build (Node 18.x)` and `CI / Build (Node 20.x)`
+- `CI / Prisma Schema (Node 18.x)` and `CI / Prisma Schema (Node 20.x)`
+- `Security / CodeQL`
+- `Security / Dependency Audit (Node 18.x)` and `Security / Dependency Audit (Node 20.x)`
+
+### D3 · Close dependabot PR #54
+**Action:** PR #54 (the Next.js 15.5.15 dependabot bump) is superseded by this PR. After this PR merges, close PR #54 without merging to keep the branch list clean.
+
+### D4 · Staging deploy + smoke test
+Before releasing to real users, deploy to a staging environment and manually verify:
+- [ ] Register a new account
+- [ ] Sign in / sign out
+- [ ] Create a project
+- [ ] Record a voice session (requires `OPENAI_API_KEY`)
+- [ ] Generate questions
+- [ ] Export at each level (raw / structured / polished / full)
+- [ ] Search within a project
+- [ ] Verify AI degraded mode: temporarily unset `OPENAI_API_KEY` and confirm the app returns a 400 (not a 500) for AI endpoints
+
+### D5 · Rollback drill
+Before go-live, confirm you can roll back:
+- Know which deployment version to revert to
+- Confirm `DATABASE_URL` points to a database that is compatible with the previous schema (SQLite with `db push` is append-only; rollback is safe)
+- Document the one-liner to revert the deployment
+
+---
+
+## Remaining open GitHub issues (4)
+
+| # | Title (short) | Section above |
+|---|---|---|
+| #22 | Export checkbox accessibility | B2 |
+| #31 | PR #21 Copilot review feedback | B4 |
+| #52 | `parseAiJsonObjectStrict` null path | B3 |
+| #59 | `ALLOWED_AUDIO_MIME_TYPES` mutable | B1 |
+
+All other issues (25 total) were confirmed fixed by merged PRs and have been closed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@next-auth/prisma-adapter": "^1.0.7",
         "@prisma/client": "^5.22.0",
-        "next": "15.5.14",
+        "next": "15.5.15",
         "next-auth": "^4.24.13",
         "openai": "^6.33.0",
         "prisma": "^5.22.0",
@@ -23,7 +23,7 @@
         "@types/react-dom": "^18",
         "dotenv": "^17.4.0",
         "eslint": "^8",
-        "eslint-config-next": "15.5.14",
+        "eslint-config-next": "15.5.15",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
         "typescript": "^5"
@@ -278,9 +278,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -296,9 +293,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -316,9 +310,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -334,9 +325,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -354,9 +342,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -372,9 +357,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -392,9 +374,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -411,9 +390,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -429,9 +405,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -455,9 +428,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -479,9 +449,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -505,9 +472,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -529,9 +493,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -555,9 +516,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -580,9 +538,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -604,9 +559,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -762,15 +714,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.14.tgz",
-      "integrity": "sha512-aXeirLYuASxEgi4X4WhfXsShCFxWDfNn/8ZeC5YXAS2BB4A8FJi1kwwGL6nvMVboE7fZCzmJPNdMvVHc8JpaiA==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.15.tgz",
+      "integrity": "sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.14.tgz",
-      "integrity": "sha512-ogBjgsFrPPz19abP3VwcYSahbkUOMMvJjxCOYWYndw+PydeMuLuB4XrvNkNutFrTjC9St2KFULRdKID8Sd/CMQ==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.15.tgz",
+      "integrity": "sha512-ExQoBfyKMjAUQ2nuF39ryQsG26H374ZfH13dlOZqf6TaE9ycRbIm+qUbUFCliU4BtQhiqtS7cnGA1yWfPMQ+jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -808,9 +760,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.14.tgz",
-      "integrity": "sha512-Y9K6SPzobnZvrRDPO2s0grgzC+Egf0CqfbdvYmQVaztV890zicw8Z8+4Vqw8oPck8r1TjUHxVh8299Cg4TrxXg==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.15.tgz",
+      "integrity": "sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==",
       "cpu": [
         "arm64"
       ],
@@ -824,9 +776,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.14.tgz",
-      "integrity": "sha512-aNnkSMjSFRTOmkd7qoNI2/rETQm/vKD6c/Ac9BZGa9CtoOzy3c2njgz7LvebQJ8iPxdeTuGnAjagyis8a9ifBw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.15.tgz",
+      "integrity": "sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==",
       "cpu": [
         "x64"
       ],
@@ -840,14 +792,11 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.14.tgz",
-      "integrity": "sha512-tjlpia+yStPRS//6sdmlVwuO1Rioern4u2onafa5n+h2hCS9MAvMXqpVbSrjgiEOoCs0nJy7oPOmWgtRRNSM5Q==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.15.tgz",
+      "integrity": "sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -859,14 +808,11 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.14.tgz",
-      "integrity": "sha512-8B8cngBaLadl5lbDRdxGCP1Lef8ipD6KlxS3v0ElDAGil6lafrAM3B258p1KJOglInCVFUjk751IXMr2ixeQOQ==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.15.tgz",
+      "integrity": "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -878,14 +824,11 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.14.tgz",
-      "integrity": "sha512-bAS6tIAg8u4Gn3Nz7fCPpSoKAexEt2d5vn1mzokcqdqyov6ZJ6gu6GdF9l8ORFrBuRHgv3go/RfzYz5BkZ6YSQ==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.15.tgz",
+      "integrity": "sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -897,14 +840,11 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.14.tgz",
-      "integrity": "sha512-mMxv/FcrT7Gfaq4tsR22l17oKWXZmH/lVqcvjX0kfp5I0lKodHYLICKPoX1KRnnE+ci6oIUdriUhuA3rBCDiSw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.15.tgz",
+      "integrity": "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -916,9 +856,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.14.tgz",
-      "integrity": "sha512-OTmiBlYThppnvnsqx0rBqjDRemlmIeZ8/o4zI7veaXoeO1PVHoyj2lfTfXTiiGjCyRDhA10y4h6ZvZvBiynr2g==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.15.tgz",
+      "integrity": "sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==",
       "cpu": [
         "arm64"
       ],
@@ -932,9 +872,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.14.tgz",
-      "integrity": "sha512-+W7eFf3RS7m4G6tppVTOSyP9Y6FsJXfOuKzav1qKniiFm3KFByQfPEcouHdjlZmysl4zJGuGLQ/M9XyVeyeNEg==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.15.tgz",
+      "integrity": "sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==",
       "cpu": [
         "x64"
       ],
@@ -1541,9 +1481,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1558,9 +1495,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1575,9 +1509,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1592,9 +1523,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1609,9 +1537,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1626,9 +1551,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1643,9 +1565,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1660,9 +1579,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2771,13 +2687,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.14.tgz",
-      "integrity": "sha512-lmJ5F8ZgOYogq0qtH4L5SpxuASY2SPdOzqUprN2/56+P3GPsIpXaUWIJC66kYIH+yZdsM4nkHE5MIBP6s1NiBw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.15.tgz",
+      "integrity": "sha512-mI5KIONOIosjF3jK2z9a8fY2LePNeW5C4lRJ+XZoJHAKkwx2MQjMPQ2/kL7tsMRPcQPZc/UBtCfqxElluL1CBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "15.5.14",
+        "@next/eslint-plugin-next": "15.5.15",
         "@rushstack/eslint-patch": "^1.10.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -4432,12 +4348,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.14.tgz",
-      "integrity": "sha512-M6S+4JyRjmKic2Ssm7jHUPkE6YUJ6lv4507jprsSZLulubz0ihO2E+S4zmQK3JZ2ov81JrugukKU4Tz0ivgqqQ==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.15.tgz",
+      "integrity": "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.14",
+        "@next/env": "15.5.15",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -4450,14 +4366,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.14",
-        "@next/swc-darwin-x64": "15.5.14",
-        "@next/swc-linux-arm64-gnu": "15.5.14",
-        "@next/swc-linux-arm64-musl": "15.5.14",
-        "@next/swc-linux-x64-gnu": "15.5.14",
-        "@next/swc-linux-x64-musl": "15.5.14",
-        "@next/swc-win32-arm64-msvc": "15.5.14",
-        "@next/swc-win32-x64-msvc": "15.5.14",
+        "@next/swc-darwin-arm64": "15.5.15",
+        "@next/swc-darwin-x64": "15.5.15",
+        "@next/swc-linux-arm64-gnu": "15.5.15",
+        "@next/swc-linux-arm64-musl": "15.5.15",
+        "@next/swc-linux-x64-gnu": "15.5.15",
+        "@next/swc-linux-x64-musl": "15.5.15",
+        "@next/swc-win32-arm64-msvc": "15.5.15",
+        "@next/swc-win32-x64-msvc": "15.5.15",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "^5.22.0",
-    "next": "15.5.14",
+    "next": "15.5.15",
     "next-auth": "^4.24.13",
     "openai": "^6.33.0",
     "prisma": "^5.22.0",
@@ -32,7 +32,7 @@
     "@types/react-dom": "^18",
     "dotenv": "^17.4.0",
     "eslint": "^8",
-    "eslint-config-next": "15.5.14",
+    "eslint-config-next": "15.5.15",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"


### PR DESCRIPTION
## What this PR does

### 1 · Security patch — Next.js 15.5.14 → 15.5.15 (CVE-2026-23869)
Supersedes dependabot PR #54. Bumps both `next` and `eslint-config-next` in `package.json` + updates `package-lock.json`. Please close PR #54 after this merges.

### 2 · Atomic deployment checklist (`docs/REMAINING_WORK.md`)
Every task still needed before shipping, written so Copilot (or any agent) can pick up any section independently:

| Section | Contents |
|---|---|
| **A — Security** | Next.js CVE (done in this PR) |
| **B — Code fixes** | 4 atomic items: `ALLOWED_AUDIO_MIME_TYPES` immutability, checkbox accessibility, `parseAiJsonObjectStrict` null test, PR #21 review follow-up |
| **C — Environment** | `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, `DATABASE_URL`, `OPENAI_API_KEY` — must be set on the hosting platform |
| **D — Deploy ops** | DB migration command, CI branch protection setup, close PR #54, staging smoke test checklist, rollback drill |

### 3 · Closed 25 stale GitHub issues
All 25 auto-filed review issues whose underlying fixes were confirmed merged have been closed. 4 real remaining items stay open (#22, #31, #52, #59) and are mapped to checklist sections B2–B4.

## After merging
- Close dependabot PR #54 (superseded)
- Have Copilot work through `docs/REMAINING_WORK.md` sections B1–B4 in separate PRs
- Complete sections C and D manually on the hosting platform

https://claude.ai/code/session_01TCrmv4Vt4u67MjzP5cr9M7