### PR TITLE
feat: add project rename/delete UI and empty states

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -54,6 +54,19 @@ export default function HomePage() {
       });
   }, []);
 
+  useEffect(() => {
+    if (!showNew) return;
+
+    const frameId = requestAnimationFrame(() => {
+      newProjectFormRef.current?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'start',
+      });
+    });
+
+    return () => cancelAnimationFrame(frameId);
+  }, [showNew]);
+
   const createProject = async () => {
     if (!newName.trim()) return;
     setCreating(true);
@@ -165,7 +178,6 @@ export default function HomePage() {
 
   const showAndScrollToNewProjectForm = () => {
     setShowNew(true);
-    setTimeout(() => newProjectFormRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' }), 50);
   };
 
   return (
@@ -306,7 +318,7 @@ export default function HomePage() {
                           Created {new Date(project.createdAt).toLocaleDateString()}
                         </p>
                       </div>
-                      <div className="flex items-center gap-1 ml-3 shrink-0" onClick={(e) => e.preventDefault()}>
+                      <div className="flex items-center gap-1 ml-3 shrink-0">
                         <button
                           onClick={(e) => startRename(project, e)}
                           aria-label={`Rename ${project.name}`}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { signOut } from 'next-auth/react';
 import { Project } from '@/lib/types';
 import { AppHeader } from '@/components/layout/app-header';
-import { Card, Container, PrimaryButton, SecondaryButton, Shell, StatusMessage, TextArea, TextInput } from '@/components/ui/primitives';
+import { Card, Container, GlassCard, PrimaryButton, SecondaryButton, Shell, StatusMessage, TextArea, TextInput, WombatMark } from '@/components/ui/primitives';
 import { toneCopy } from '@/lib/copy/tone';
 import { requestJson } from '@/lib/client/request';
 
@@ -28,6 +28,16 @@ export default function HomePage() {
   const [newDesc, setNewDesc] = useState('');
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+  const [renameDesc, setRenameDesc] = useState('');
+  const [renaming, setRenaming] = useState(false);
+
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const newProjectFormRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     requestJson<Project[]>('/api/projects')
@@ -76,6 +86,88 @@ export default function HomePage() {
     }
   };
 
+  const startRename = (project: Project, e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setRenamingId(project.id);
+    setRenameValue(project.name);
+    setRenameDesc(project.description ?? '');
+    setDeletingId(null);
+    setError(null);
+  };
+
+  const cancelRename = () => {
+    setRenamingId(null);
+    setRenameValue('');
+    setRenameDesc('');
+  };
+
+  const submitRename = async (projectId: string) => {
+    if (!renameValue.trim()) return;
+    setRenaming(true);
+    setError(null);
+    try {
+      const res = await requestJson<Project | { error?: string }>(`/api/projects/${projectId}`, {
+        method: 'PATCH',
+        body: { name: renameValue.trim(), description: renameDesc },
+      });
+
+      if (!res.ok || !res.data) {
+        const failure = res.data as { error?: string } | null;
+        throw new Error(failure?.error || 'Could not rename project');
+      }
+
+      if (!isProjectPayload(res.data)) {
+        throw new Error('Could not rename project');
+      }
+
+      const updated = res.data;
+      setProjects((prev) => prev.map((p) => (p.id === projectId ? updated : p)));
+      cancelRename();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not rename project');
+    } finally {
+      setRenaming(false);
+    }
+  };
+
+  const startDelete = (projectId: string, e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDeletingId(projectId);
+    setRenamingId(null);
+    setError(null);
+  };
+
+  const cancelDelete = () => setDeletingId(null);
+
+  const confirmDelete = async (projectId: string) => {
+    setDeleting(true);
+    setError(null);
+    try {
+      const res = await requestJson<{ success?: boolean; error?: string }>(`/api/projects/${projectId}`, {
+        method: 'DELETE',
+      });
+
+      if (!res.ok) {
+        const failure = res.data as { error?: string } | null;
+        throw new Error(failure?.error || 'Could not delete project');
+      }
+
+      setProjects((prev) => prev.filter((p) => p.id !== projectId));
+      setDeletingId(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not delete project');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const showAndScrollToNewProjectForm = () => {
+    setShowNew(true);
+    setTimeout(() => newProjectFormRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' }), 50);
+  };
+
   return (
     <Shell>
       <Container>
@@ -96,69 +188,145 @@ export default function HomePage() {
           <PrimaryButton onClick={() => setShowNew(true)}>+ New Project</PrimaryButton>
         </div>
 
-        {showNew && (
-          <Card className="mb-6">
-            <h3 className="text-lg font-semibold mb-4">New Project</h3>
-            <TextInput
-              type="text"
-              placeholder="Project name..."
-              value={newName}
-              onChange={(e) => setNewName(e.target.value)}
-              className="mb-3"
-              onKeyDown={(e) => e.key === 'Enter' && createProject()}
-              autoFocus
-            />
-            <TextArea
-              placeholder="What is this project? (optional)"
-              value={newDesc}
-              onChange={(e) => setNewDesc(e.target.value)}
-              rows={3}
-              className="mb-4 resize-none"
-            />
-            <div className="flex gap-3">
-              <PrimaryButton onClick={createProject} disabled={creating || !newName.trim()}>
-                {creating ? 'Creating...' : 'Create'}
-              </PrimaryButton>
-              <SecondaryButton onClick={() => setShowNew(false)}>
-                Cancel
-              </SecondaryButton>
-            </div>
-          </Card>
-        )}
+        <div ref={newProjectFormRef}>
+          {showNew && (
+            <Card className="mb-6">
+              <h3 className="text-lg font-semibold mb-4">New Project</h3>
+              <TextInput
+                type="text"
+                placeholder="Project name..."
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                className="mb-3"
+                onKeyDown={(e) => e.key === 'Enter' && createProject()}
+                autoFocus
+              />
+              <TextArea
+                placeholder="What is this project? (optional)"
+                value={newDesc}
+                onChange={(e) => setNewDesc(e.target.value)}
+                rows={3}
+                className="mb-4 resize-none"
+              />
+              <div className="flex gap-3">
+                <PrimaryButton onClick={createProject} disabled={creating || !newName.trim()}>
+                  {creating ? 'Creating...' : 'Create'}
+                </PrimaryButton>
+                <SecondaryButton onClick={() => setShowNew(false)}>
+                  Cancel
+                </SecondaryButton>
+              </div>
+            </Card>
+          )}
+        </div>
 
         {error && <StatusMessage state="error" title="Something went wrong" description={error} />}
 
         {loading ? (
           <StatusMessage state="loading" title={toneCopy.homeLoadingProjects} />
         ) : projects.length === 0 ? (
-          <Card className="text-center py-16">
-            <div className="text-6xl mb-4">🎙️</div>
-            <p className="text-xl mb-2 text-white">{toneCopy.homeEmptyProjectsTitle}</p>
-            <p className="text-app-fg-muted">{toneCopy.homeEmptyProjectsDescription}</p>
-          </Card>
+          <GlassCard className="text-center py-16">
+            <div className="flex justify-center mb-6">
+              <WombatMark size={72} />
+            </div>
+            <p className="text-2xl font-bold mb-3 text-white">Your first story starts here.</p>
+            <p className="text-app-fg-muted mb-2 max-w-md mx-auto">
+              Talk freely — fragments, hunches, half-finished thoughts. The Wombat maps what connects, what&apos;s missing, and what keeps resurfacing.
+            </p>
+            <p className="text-app-fg-muted mb-8 max-w-md mx-auto text-sm">
+              Create a project to begin. Everything else follows from recording.
+            </p>
+            <PrimaryButton onClick={showAndScrollToNewProjectForm} className="px-6 py-3 text-base">
+              Create your first project
+            </PrimaryButton>
+          </GlassCard>
         ) : (
           <div className="grid gap-4">
             {projects.map((project) => (
-              <Link
-                key={project.id}
-                href={`/project/${project.id}`}
-                className="group block rounded-2xl border border-app-border bg-app-surface p-6 shadow-app transition duration-200 hover:border-app-border-strong hover:-translate-y-0.5"
-              >
-                <div className="flex items-start justify-between">
-                  <div>
-                    <h3 className="truncate text-lg font-semibold text-white transition-colors group-hover:text-indigo-300">
-                      {project.name}
-                    </h3>
-                    {project.description && (
-                      <p className="mt-1 line-clamp-1 text-sm text-app-fg-muted">{project.description}</p>
-                    )}
-                    <p className="mt-2 text-xs text-app-fg-muted">
-                      Created {new Date(project.createdAt).toLocaleDateString()}
+              <div key={project.id} className="relative">
+                {renamingId === project.id ? (
+                  <Card className="border-indigo-700">
+                    <h3 className="text-sm font-semibold text-app-fg-muted mb-3">Rename project</h3>
+                    <TextInput
+                      type="text"
+                      placeholder="Project name..."
+                      value={renameValue}
+                      onChange={(e) => setRenameValue(e.target.value)}
+                      className="mb-3"
+                      onKeyDown={(e) => e.key === 'Enter' && submitRename(project.id)}
+                      autoFocus
+                    />
+                    <TextArea
+                      placeholder="Description (optional)"
+                      value={renameDesc}
+                      onChange={(e) => setRenameDesc(e.target.value)}
+                      rows={2}
+                      className="mb-4 resize-none"
+                    />
+                    <div className="flex gap-3">
+                      <PrimaryButton
+                        onClick={() => submitRename(project.id)}
+                        disabled={renaming || !renameValue.trim()}
+                      >
+                        {renaming ? 'Saving...' : 'Save'}
+                      </PrimaryButton>
+                      <SecondaryButton onClick={cancelRename}>Cancel</SecondaryButton>
+                    </div>
+                  </Card>
+                ) : deletingId === project.id ? (
+                  <Card className="border-red-700 bg-red-900/20">
+                    <p className="text-sm text-red-300 mb-4">
+                      Delete <strong>{project.name}</strong>? This cannot be undone.
                     </p>
-                  </div>
-                  <span className="text-app-fg-muted transition-colors group-hover:text-indigo-300">→</span>
-                </div>
-              </Link>
+                    <div className="flex gap-3">
+                      <PrimaryButton
+                        onClick={() => confirmDelete(project.id)}
+                        disabled={deleting}
+                        className="bg-red-600 hover:brightness-110 glow-lime-none"
+                      >
+                        {deleting ? 'Deleting...' : 'Delete permanently'}
+                      </PrimaryButton>
+                      <SecondaryButton onClick={cancelDelete}>Cancel</SecondaryButton>
+                    </div>
+                  </Card>
+                ) : (
+                  <Link
+                    href={`/project/${project.id}`}
+                    className="group block rounded-2xl border border-app-border bg-app-surface p-6 shadow-app transition duration-200 hover:border-app-border-strong hover:-translate-y-0.5"
+                  >
+                    <div className="flex items-start justify-between">
+                      <div className="min-w-0 flex-1">
+                        <h3 className="truncate text-lg font-semibold text-white transition-colors group-hover:text-indigo-300">
+                          {project.name}
+                        </h3>
+                        {project.description && (
+                          <p className="mt-1 line-clamp-1 text-sm text-app-fg-muted">{project.description}</p>
+                        )}
+                        <p className="mt-2 text-xs text-app-fg-muted">
+                          Created {new Date(project.createdAt).toLocaleDateString()}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-1 ml-3 shrink-0" onClick={(e) => e.preventDefault()}>
+                        <button
+                          onClick={(e) => startRename(project, e)}
+                          aria-label={`Rename ${project.name}`}
+                          className="rounded-lg p-1.5 text-app-fg-muted transition hover:bg-app-surface-strong hover:text-white"
+                        >
+                          ✏️
+                        </button>
+                        <button
+                          onClick={(e) => startDelete(project.id, e)}
+                          aria-label={`Delete ${project.name}`}
+                          className="rounded-lg p-1.5 text-app-fg-muted transition hover:bg-red-900/30 hover:text-red-400"
+                        >
+                          🗑️
+                        </button>
+                        <span className="text-app-fg-muted transition-colors group-hover:text-indigo-300 ml-1">→</span>
+                      </div>
+                    </div>
+                  </Link>
+                )}
+              </div>
             ))}
           </div>
         )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,17 +8,7 @@ import { AppHeader } from '@/components/layout/app-header';
 import { Card, Container, GlassCard, PrimaryButton, SecondaryButton, Shell, StatusMessage, TextArea, TextInput, WombatMark } from '@/components/ui/primitives';
 import { toneCopy } from '@/lib/copy/tone';
 import { requestJson } from '@/lib/client/request';
-
-function isProjectPayload(value: unknown): value is Project {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'id' in value &&
-    typeof value.id === 'string' &&
-    'name' in value &&
-    typeof value.name === 'string'
-  );
-}
+import { isProjectPayload, updateProjectName, deleteProject } from '@/lib/client/project-operations';
 
 export default function HomePage() {
   const [projects, setProjects] = useState<Project[]>([]);
@@ -120,21 +110,7 @@ export default function HomePage() {
     setRenaming(true);
     setError(null);
     try {
-      const res = await requestJson<Project | { error?: string }>(`/api/projects/${projectId}`, {
-        method: 'PATCH',
-        body: { name: renameValue.trim(), description: renameDesc },
-      });
-
-      if (!res.ok || !res.data) {
-        const failure = res.data as { error?: string } | null;
-        throw new Error(failure?.error || 'Could not rename project');
-      }
-
-      if (!isProjectPayload(res.data)) {
-        throw new Error('Could not rename project');
-      }
-
-      const updated = res.data;
+      const updated = await updateProjectName(projectId, renameValue, renameDesc);
       setProjects((prev) => prev.map((p) => (p.id === projectId ? { ...p, ...updated } : p)));
       cancelRename();
     } catch (err) {
@@ -158,15 +134,7 @@ export default function HomePage() {
     setDeleting(true);
     setError(null);
     try {
-      const res = await requestJson<{ success?: boolean; error?: string }>(`/api/projects/${projectId}`, {
-        method: 'DELETE',
-      });
-
-      if (!res.ok) {
-        const failure = res.data as { error?: string } | null;
-        throw new Error(failure?.error || 'Could not delete project');
-      }
-
+      await deleteProject(projectId);
       setProjects((prev) => prev.filter((p) => p.id !== projectId));
       setDeletingId(null);
     } catch (err) {
@@ -265,7 +233,7 @@ export default function HomePage() {
                       value={renameValue}
                       onChange={(e) => setRenameValue(e.target.value)}
                       className="mb-3"
-                      onKeyDown={(e) => e.key === 'Enter' && submitRename(project.id)}
+                      onKeyDown={(e) => e.key === 'Enter' && !renaming && submitRename(project.id)}
                       autoFocus
                     />
                     <TextArea

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, type MouseEvent } from 'react';
 import Link from 'next/link';
 import { signOut } from 'next-auth/react';
 import { Project } from '@/lib/types';
@@ -99,7 +99,7 @@ export default function HomePage() {
     }
   };
 
-  const startRename = (project: Project, e: React.MouseEvent) => {
+  const startRename = (project: Project, e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     e.stopPropagation();
     setRenamingId(project.id);
@@ -135,7 +135,7 @@ export default function HomePage() {
       }
 
       const updated = res.data;
-      setProjects((prev) => prev.map((p) => (p.id === projectId ? updated : p)));
+      setProjects((prev) => prev.map((p) => (p.id === projectId ? { ...p, ...updated } : p)));
       cancelRename();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Could not rename project');
@@ -144,7 +144,7 @@ export default function HomePage() {
     }
   };
 
-  const startDelete = (projectId: string, e: React.MouseEvent) => {
+  const startDelete = (projectId: string, e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     e.stopPropagation();
     setDeletingId(projectId);

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -8,17 +8,7 @@ import { AppBackLink, Card, Container, PrimaryButton, SecondaryButton, Shell, St
 import { useProjectDashboard } from '@/components/project/dashboard/use-project-dashboard';
 import { requestJson } from '@/lib/client/request';
 import { Project } from '@/lib/types';
-
-function isProjectPayload(value: unknown): value is Project {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'id' in value &&
-    typeof value.id === 'string' &&
-    'name' in value &&
-    typeof value.name === 'string'
-  );
-}
+import { updateProjectName } from '@/lib/client/project-operations';
 import { DashboardActionCards } from '@/components/project/dashboard/dashboard-action-cards';
 import { DashboardInsightsGrid } from '@/components/project/dashboard/dashboard-insights-grid';
 import { DashboardQuestionsCard } from '@/components/project/dashboard/dashboard-questions-card';
@@ -69,21 +59,7 @@ export default function ProjectPage() {
     setRenaming(true);
     setRenameError(null);
     try {
-      const res = await requestJson<Project | { error?: string }>(`/api/projects/${id}`, {
-        method: 'PATCH',
-        body: { name: renameValue.trim(), description: renameDesc },
-      });
-
-      if (!res.ok || !res.data) {
-        const failure = res.data as { error?: string } | null;
-        throw new Error(failure?.error || 'Could not rename project');
-      }
-
-      if (!isProjectPayload(res.data)) {
-        throw new Error('Could not rename project');
-      }
-
-      const updated = res.data;
+      const updated = await updateProjectName(id, renameValue, renameDesc);
       setProject((prev) => (prev ? { ...prev, ...updated } : updated));
       setShowRename(false);
     } catch (err) {

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -6,8 +6,6 @@ import Link from 'next/link';
 import { AppHeader } from '@/components/layout/app-header';
 import { AppBackLink, Card, Container, PrimaryButton, SecondaryButton, Shell, StatusMessage, TextArea, TextInput } from '@/components/ui/primitives';
 import { useProjectDashboard } from '@/components/project/dashboard/use-project-dashboard';
-import { requestJson } from '@/lib/client/request';
-import { Project } from '@/lib/types';
 import { updateProjectName } from '@/lib/client/project-operations';
 import { DashboardActionCards } from '@/components/project/dashboard/dashboard-action-cards';
 import { DashboardInsightsGrid } from '@/components/project/dashboard/dashboard-insights-grid';

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -1,10 +1,13 @@
 'use client';
 
+import { useState } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { AppHeader } from '@/components/layout/app-header';
-import { AppBackLink, Card, Container, Shell, StatusMessage } from '@/components/ui/primitives';
+import { AppBackLink, Card, Container, PrimaryButton, SecondaryButton, Shell, StatusMessage, TextArea, TextInput } from '@/components/ui/primitives';
 import { useProjectDashboard } from '@/components/project/dashboard/use-project-dashboard';
+import { requestJson } from '@/lib/client/request';
+import { Project } from '@/lib/types';
 import { DashboardActionCards } from '@/components/project/dashboard/dashboard-action-cards';
 import { DashboardInsightsGrid } from '@/components/project/dashboard/dashboard-insights-grid';
 import { DashboardQuestionsCard } from '@/components/project/dashboard/dashboard-questions-card';
@@ -33,7 +36,47 @@ export default function ProjectPage() {
     updateConcept,
     updateContradiction,
     searchProject,
+    setProject,
   } = useProjectDashboard(id);
+
+  const [showRename, setShowRename] = useState(false);
+  const [renameValue, setRenameValue] = useState('');
+  const [renameDesc, setRenameDesc] = useState('');
+  const [renaming, setRenaming] = useState(false);
+  const [renameError, setRenameError] = useState<string | null>(null);
+
+  const openRename = () => {
+    if (!project) return;
+    setRenameValue(project.name);
+    setRenameDesc(project.description ?? '');
+    setRenameError(null);
+    setShowRename(true);
+  };
+
+  const submitRename = async () => {
+    if (!renameValue.trim() || !project) return;
+    setRenaming(true);
+    setRenameError(null);
+    try {
+      const res = await requestJson<Project | { error?: string }>(`/api/projects/${id}`, {
+        method: 'PATCH',
+        body: { name: renameValue.trim(), description: renameDesc },
+      });
+
+      if (!res.ok || !res.data) {
+        const failure = res.data as { error?: string } | null;
+        throw new Error(failure?.error || 'Could not rename project');
+      }
+
+      const updated = res.data as Project;
+      setProject(updated);
+      setShowRename(false);
+    } catch (err) {
+      setRenameError(err instanceof Error ? err.message : 'Could not rename project');
+    } finally {
+      setRenaming(false);
+    }
+  };
 
   if (loading) {
     return <Shell><Container><StatusMessage state="loading" title="Loading project..." /></Container></Shell>;
@@ -49,12 +92,55 @@ export default function ProjectPage() {
     );
   }
 
+  const sessionCount = project.sessions?.length || 0;
+
   return (
     <Shell>
       <Container wide>
         <AppBackLink href="/" label="Projects" />
         <div className="mt-4" />
-        <AppHeader title={project.name} subtitle={project.description || undefined} showMark />
+
+        {showRename ? (
+          <Card className="mb-6 border-indigo-700">
+            <h3 className="text-sm font-semibold text-app-fg-muted mb-3">Rename project</h3>
+            <TextInput
+              type="text"
+              placeholder="Project name..."
+              value={renameValue}
+              onChange={(e) => setRenameValue(e.target.value)}
+              className="mb-3"
+              onKeyDown={(e) => e.key === 'Enter' && submitRename()}
+              autoFocus
+            />
+            <TextArea
+              placeholder="Description (optional)"
+              value={renameDesc}
+              onChange={(e) => setRenameDesc(e.target.value)}
+              rows={2}
+              className="mb-4 resize-none"
+            />
+            {renameError && <p className="text-sm text-red-400 mb-3">{renameError}</p>}
+            <div className="flex gap-3">
+              <PrimaryButton onClick={submitRename} disabled={renaming || !renameValue.trim()}>
+                {renaming ? 'Saving...' : 'Save'}
+              </PrimaryButton>
+              <SecondaryButton onClick={() => setShowRename(false)}>Cancel</SecondaryButton>
+            </div>
+          </Card>
+        ) : (
+          <div className="flex items-start gap-3">
+            <div className="flex-1">
+              <AppHeader title={project.name} subtitle={project.description || undefined} showMark />
+            </div>
+            <button
+              onClick={openRename}
+              aria-label="Rename project"
+              className="mt-1 rounded-lg p-1.5 text-app-fg-muted transition hover:bg-app-surface-strong hover:text-white shrink-0"
+            >
+              ✏️
+            </button>
+          </div>
+        )}
 
         {actionError && (
           <div role="alert">
@@ -64,38 +150,64 @@ export default function ProjectPage() {
           </div>
         )}
 
-        <DashboardActionCards
-          id={id}
-          documentCount={project.documents?.length || 0}
-          sessionCount={project.sessions?.length || 0}
-        />
+        {sessionCount === 0 ? (
+          <Card className="mb-6 text-center py-12">
+            <div className="text-4xl mb-4">🎙️</div>
+            <h2 className="text-xl font-bold text-white mb-6">Ready to start?</h2>
+            <div className="max-w-md mx-auto space-y-4 text-left mb-8">
+              <div className="flex gap-3 items-start">
+                <span className="text-neon-lime font-bold shrink-0">1</span>
+                <p className="text-app-fg-muted text-sm">Hit Record and just talk. Don&apos;t worry about what to say.</p>
+              </div>
+              <div className="flex gap-3 items-start">
+                <span className="text-neon-lime font-bold shrink-0">2</span>
+                <p className="text-app-fg-muted text-sm">The Wombat will find the threads, contradictions, and moments that matter.</p>
+              </div>
+              <div className="flex gap-3 items-start">
+                <span className="text-neon-lime font-bold shrink-0">3</span>
+                <p className="text-app-fg-muted text-sm">Come back and keep going. The more you record, the richer the analysis.</p>
+              </div>
+            </div>
+            <Link href={`/project/${id}/record`}>
+              <PrimaryButton className="px-6 py-3 text-base">Start recording</PrimaryButton>
+            </Link>
+          </Card>
+        ) : (
+          <>
+            <DashboardActionCards
+              id={id}
+              documentCount={project.documents?.length || 0}
+              sessionCount={sessionCount}
+            />
 
-        <DashboardInsightsGrid
-          id={id}
-          pendingTangents={pendingTangents}
-          openGaps={openGaps}
-          newPatterns={newPatterns}
-          onResolveTangent={resolveTangent}
-          onResolveGap={resolveGap}
-        />
+            <DashboardInsightsGrid
+              id={id}
+              pendingTangents={pendingTangents}
+              openGaps={openGaps}
+              newPatterns={newPatterns}
+              onResolveTangent={resolveTangent}
+              onResolveGap={resolveGap}
+            />
 
-        <DashboardQuestionsCard id={id} pendingQuestionsCount={pendingQuestions.length} />
+            <DashboardQuestionsCard id={id} pendingQuestionsCount={pendingQuestions.length} />
 
-        <DashboardConceptsContradictions
-          id={id}
-          pendingConcepts={pendingConcepts}
-          openContradictions={openContradictions}
-          onApproveConcept={(conceptId) => updateConcept(conceptId, true)}
-          onMarkContradictionExplored={(contradictionId) => updateContradiction(contradictionId, 'explored')}
-        />
+            <DashboardConceptsContradictions
+              id={id}
+              pendingConcepts={pendingConcepts}
+              openContradictions={openContradictions}
+              onApproveConcept={(conceptId) => updateConcept(conceptId, true)}
+              onMarkContradictionExplored={(contradictionId) => updateContradiction(contradictionId, 'explored')}
+            />
 
-        <DashboardSearchCard
-          searchTerm={searchTerm}
-          searching={searching}
-          searchResults={searchResults}
-          onSearchTermChange={setSearchTerm}
-          onSearch={searchProject}
-        />
+            <DashboardSearchCard
+              searchTerm={searchTerm}
+              searching={searching}
+              searchResults={searchResults}
+              onSearchTermChange={setSearchTerm}
+              onSearch={searchProject}
+            />
+          </>
+        )}
 
         <div className="mt-6 flex flex-wrap gap-3 text-sm">
           {['gaps', 'tangents', 'patterns', 'concepts', 'contradictions', 'search'].map((route) => (

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -8,6 +8,17 @@ import { AppBackLink, Card, Container, PrimaryButton, SecondaryButton, Shell, St
 import { useProjectDashboard } from '@/components/project/dashboard/use-project-dashboard';
 import { requestJson } from '@/lib/client/request';
 import { Project } from '@/lib/types';
+
+function isProjectPayload(value: unknown): value is Project {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'id' in value &&
+    typeof value.id === 'string' &&
+    'name' in value &&
+    typeof value.name === 'string'
+  );
+}
 import { DashboardActionCards } from '@/components/project/dashboard/dashboard-action-cards';
 import { DashboardInsightsGrid } from '@/components/project/dashboard/dashboard-insights-grid';
 import { DashboardQuestionsCard } from '@/components/project/dashboard/dashboard-questions-card';
@@ -68,8 +79,12 @@ export default function ProjectPage() {
         throw new Error(failure?.error || 'Could not rename project');
       }
 
-      const updated = res.data as Project;
-      setProject(updated);
+      if (!isProjectPayload(res.data)) {
+        throw new Error('Could not rename project');
+      }
+
+      const updated = res.data;
+      setProject((prev) => (prev ? { ...prev, ...updated } : updated));
       setShowRename(false);
     } catch (err) {
       setRenameError(err instanceof Error ? err.message : 'Could not rename project');

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -109,7 +109,11 @@ export default function ProjectPage() {
               value={renameValue}
               onChange={(e) => setRenameValue(e.target.value)}
               className="mb-3"
-              onKeyDown={(e) => e.key === 'Enter' && submitRename()}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !renaming && renameValue.trim()) {
+                  submitRename();
+                }
+              }}
               autoFocus
             />
             <TextArea

--- a/src/app/project/[id]/record/page.tsx
+++ b/src/app/project/[id]/record/page.tsx
@@ -91,6 +91,8 @@ function RecordingControlCard({
   );
 }
 
+const getHintDismissalKey = (projectId: string) => `hint-dismissed-${projectId}`;
+
 function AnalysisPanels({ analysis }: { analysis: AnalysisResult }) {
   return (
     <>
@@ -199,6 +201,15 @@ export default function RecordPage() {
   const [duration, setDuration] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const [liveTranscript, setLiveTranscript] = useState('');
+  const [showFirstVisitHint, setShowFirstVisitHint] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return localStorage.getItem(getHintDismissalKey(id)) !== 'true';
+  });
+
+  const dismissFirstVisitHint = () => {
+    localStorage.setItem(getHintDismissalKey(id), 'true');
+    setShowFirstVisitHint(false);
+  };
 
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const chunksRef = useRef<Blob[]>([]);
@@ -328,6 +339,21 @@ export default function RecordPage() {
         <AppHeader title="Voice Session" subtitle={toneCopy.recordHeaderSubtitle} />
 
         {error && <StatusMessage state="error" title="Recording error" description={error} />}
+
+        {showFirstVisitHint && (
+          <Card className="mb-6 border-neon-lime/30 bg-app-surface-muted flex items-start justify-between gap-4">
+            <p className="text-sm text-app-fg-muted">
+              Just talk. Tell a story, any story. The Wombat will do the rest.
+            </p>
+            <button
+              onClick={dismissFirstVisitHint}
+              aria-label="Dismiss hint"
+              className="shrink-0 text-app-fg-muted hover:text-white transition text-xs"
+            >
+              ✕
+            </button>
+          </Card>
+        )}
 
         {questionId && (
           <div className="bg-indigo-900/30 border border-indigo-700 rounded-xl p-4 mb-6">

--- a/src/app/project/[id]/record/page.tsx
+++ b/src/app/project/[id]/record/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { useParams, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { AnalysisResult } from '@/lib/types';
@@ -202,28 +202,23 @@ export default function RecordPage() {
   const [error, setError] = useState<string | null>(null);
   const [liveTranscript, setLiveTranscript] = useState('');
 
-  const getShouldShowFirstVisitHint = () => {
-    if (typeof window === 'undefined') return false;
+  const [showFirstVisitHint, setShowFirstVisitHint] = useState(false);
 
+  useEffect(() => {
     try {
-      return localStorage.getItem(getHintDismissalKey(id)) !== 'true';
+      const isDismissed = localStorage.getItem(getHintDismissalKey(id)) === 'true';
+      setShowFirstVisitHint(!isDismissed);
     } catch {
-      return true;
+      setShowFirstVisitHint(true);
     }
-  };
+  }, [id]);
 
-  const persistFirstVisitHintDismissal = () => {
+  const dismissFirstVisitHint = () => {
     try {
       localStorage.setItem(getHintDismissalKey(id), 'true');
     } catch {
       // Ignore storage failures and still dismiss the hint for the current render.
     }
-  };
-
-  const [showFirstVisitHint, setShowFirstVisitHint] = useState(() => getShouldShowFirstVisitHint());
-
-  const dismissFirstVisitHint = () => {
-    persistFirstVisitHintDismissal();
     setShowFirstVisitHint(false);
   };
 

--- a/src/app/project/[id]/record/page.tsx
+++ b/src/app/project/[id]/record/page.tsx
@@ -205,12 +205,32 @@ export default function RecordPage() {
   const [showFirstVisitHint, setShowFirstVisitHint] = useState(false);
 
   useEffect(() => {
-    try {
-      const isDismissed = localStorage.getItem(getHintDismissalKey(id)) === 'true';
-      setShowFirstVisitHint(!isDismissed);
-    } catch {
-      setShowFirstVisitHint(true);
-    }
+    const checkAndShowHint = async () => {
+      try {
+        const isDismissed = localStorage.getItem(getHintDismissalKey(id)) === 'true';
+        if (isDismissed) {
+          setShowFirstVisitHint(false);
+          return;
+        }
+
+        // Fetch project to check sessionCount
+        const res = await fetch(`/api/projects/${id}`);
+        if (!res.ok) {
+          setShowFirstVisitHint(true);
+          return;
+        }
+
+        const project = await res.json();
+        const sessionCount = project.sessions?.length || 0;
+        // Only show hint on first visit (no sessions yet)
+        setShowFirstVisitHint(sessionCount === 0);
+      } catch {
+        // If we can't verify, show the hint as a fallback
+        setShowFirstVisitHint(true);
+      }
+    };
+
+    checkAndShowHint();
   }, [id]);
 
   const dismissFirstVisitHint = () => {

--- a/src/app/project/[id]/record/page.tsx
+++ b/src/app/project/[id]/record/page.tsx
@@ -201,13 +201,29 @@ export default function RecordPage() {
   const [duration, setDuration] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const [liveTranscript, setLiveTranscript] = useState('');
-  const [showFirstVisitHint, setShowFirstVisitHint] = useState(() => {
+
+  const getShouldShowFirstVisitHint = () => {
     if (typeof window === 'undefined') return false;
-    return localStorage.getItem(getHintDismissalKey(id)) !== 'true';
-  });
+
+    try {
+      return localStorage.getItem(getHintDismissalKey(id)) !== 'true';
+    } catch {
+      return true;
+    }
+  };
+
+  const persistFirstVisitHintDismissal = () => {
+    try {
+      localStorage.setItem(getHintDismissalKey(id), 'true');
+    } catch {
+      // Ignore storage failures and still dismiss the hint for the current render.
+    }
+  };
+
+  const [showFirstVisitHint, setShowFirstVisitHint] = useState(() => getShouldShowFirstVisitHint());
 
   const dismissFirstVisitHint = () => {
-    localStorage.setItem(getHintDismissalKey(id), 'true');
+    persistFirstVisitHintDismissal();
     setShowFirstVisitHint(false);
   };
 

--- a/src/components/project/dashboard/use-project-dashboard.ts
+++ b/src/components/project/dashboard/use-project-dashboard.ts
@@ -363,5 +363,6 @@ export function useProjectDashboard(projectId: string) {
     updateConcept,
     updateContradiction,
     searchProject,
+    setProject,
   };
 }

--- a/src/lib/client/project-operations.ts
+++ b/src/lib/client/project-operations.ts
@@ -1,0 +1,46 @@
+import { requestJson } from './request';
+import { Project } from '@/lib/types';
+
+export function isProjectPayload(value: unknown): value is Project {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'id' in value &&
+    typeof value.id === 'string' &&
+    'name' in value &&
+    typeof value.name === 'string'
+  );
+}
+
+export async function updateProjectName(
+  projectId: string,
+  name: string,
+  description?: string | null,
+): Promise<Project> {
+  const res = await requestJson<Project | { error?: string }>(`/api/projects/${projectId}`, {
+    method: 'PATCH',
+    body: { name: name.trim(), description },
+  });
+
+  if (!res.ok || !res.data) {
+    const failure = res.data as { error?: string } | null;
+    throw new Error(failure?.error || 'Could not rename project');
+  }
+
+  if (!isProjectPayload(res.data)) {
+    throw new Error('Could not rename project');
+  }
+
+  return res.data;
+}
+
+export async function deleteProject(projectId: string): Promise<void> {
+  const res = await requestJson<{ success?: boolean; error?: string }>(`/api/projects/${projectId}`, {
+    method: 'DELETE',
+  });
+
+  if (!res.ok) {
+    const failure = res.data as { error?: string } | null;
+    throw new Error(failure?.error || 'Could not delete project');
+  }
+}


### PR DESCRIPTION
## Summary

Adds UX improvements for project management and onboarding: inline rename/delete forms on project cards, empty state redesign, and first-visit hints.

### Features

**Project rename/delete UI (#64)**
- Each project card gains ✏️ / 🗑️ buttons that trigger inline forms
- No modal dependencies; forms appear inline on the card
- Dashboard header includes rename button for project title
- `useProjectDashboard` now exposes `setProject` for immediate UI updates

**Empty states and onboarding (#67)**
- **Home (no projects):** Redesigned with `GlassCard`, `WombatMark`, and compelling headline "Your first story starts here"
- **Project dashboard (no sessions):** 3-step onboarding card with guidance and CTA to record
- **Record page:** Dismissible first-visit hint card with localStorage persistence per project

### Testing

- Build and lint pass
- All components render without errors
- Record page hint dismissal uses localStorage to avoid showing on repeat visits
- Rename/delete operations properly update project list state

### Issue Resolution

Closes #64 (project rename/delete UI) and #67 (empty states and onboarding)

https://claude.ai/code/session_01XQbFStmgTrHtZwvTyWSzAV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQbFStmgTrHtZwvTyWSzAV)_

## Summary by Sourcery

Add inline project rename/delete controls and onboarding-focused empty states across the home, project dashboard, and record pages.

New Features:
- Allow projects to be renamed and deleted inline from the home project list without modals.
- Allow project details to be renamed directly from the project dashboard header.
- Introduce a redesigned empty state for users with no projects, encouraging creation of the first project.
- Show a guided onboarding card on project dashboards with no recording sessions, prompting users to start recording.
- Display a dismissible first-visit hint on the project record page, persisted per project in localStorage.

Enhancements:
- Ensure new-project form can be scrolled into view when triggered from the empty state CTA.
- Expose setProject from useProjectDashboard so the dashboard can immediately reflect project updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rename and delete actions for projects in the projects list
  * Added inline rename functionality on the project page
  * Added empty-state view for projects with no sessions
  * Added first-visit hint in the recording interface for new projects
  * Improved "New Project" form accessibility with automatic scrolling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->