### PR TITLE
🎨 Palette: Add contextual ARIA labels and focus rings to dashboard lists and search

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-05 - Contextual ARIA labels for inline list buttons
+**Learning:** When rendering lists of items (like "Concepts", "Contradictions", or "Dropped Threads") that each have an inline action button labeled just "✓ Approve" or "✓ Resolved", screen reader users hear repeated, indistinguishable actions. Focus states also sometimes look awkward without slight padding and negative margin adjustments (`px-1 -ml-1`).
+**Action:** Always add contextual `aria-label`s (e.g., `aria-label={\`Resolve dropped thread: \${tangent.thread}\`}`) to inline list action buttons. Include `focus-visible` rings with padding/margins to ensure keyboard navigators can visually distinguish the active item without layout shift.

--- a/src/app/api/__tests__/route-handlers.contract.test.ts
+++ b/src/app/api/__tests__/route-handlers.contract.test.ts
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { File } from 'node:buffer';
 import { POST as registerPOST } from '@/app/api/auth/register/route';
 import { POST as questionsPOST } from '@/app/api/projects/[id]/questions/route';
 import { POST as transcribePOST } from '@/app/api/transcribe/route';

--- a/src/app/api/__tests__/transcribe.contract.test.ts
+++ b/src/app/api/__tests__/transcribe.contract.test.ts
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { File } from 'node:buffer';
 import { handleRoute } from '@/lib/server/http';
 import { AppError, badRequest } from '@/lib/server/errors';
 import { parseTranscribeRequest, validateTranscribeAudioFile, ALLOWED_AUDIO_MIME_TYPES } from '@/lib/server/routes/transcribe';

--- a/src/components/project/dashboard/dashboard-concepts-contradictions.tsx
+++ b/src/components/project/dashboard/dashboard-concepts-contradictions.tsx
@@ -23,7 +23,8 @@ export function DashboardConceptsContradictions({
                 <p className="text-xs text-app-fg-muted mt-1">{concept.definition}</p>
                 <button
                   onClick={() => onApproveConcept(concept.id)}
-                  className="text-xs text-neon-lime/70 hover:text-neon-lime mt-2 transition-colors"
+                  aria-label={`Approve concept: ${concept.name}`}
+                  className="text-xs text-neon-lime/70 hover:text-neon-lime mt-2 transition-colors rounded px-1 -ml-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-neon-lime"
                 >
                   ✓ Approve
                 </button>
@@ -48,7 +49,8 @@ export function DashboardConceptsContradictions({
                 <p className="text-sm text-neon-pink">{item.description}</p>
                 <button
                   onClick={() => onMarkContradictionExplored(item.id)}
-                  className="text-xs text-neon-lime/70 hover:text-neon-lime mt-2 transition-colors"
+                  aria-label={`Mark contradiction explored: ${item.description.slice(0, 30)}...`}
+                  className="text-xs text-neon-lime/70 hover:text-neon-lime mt-2 transition-colors rounded px-1 -ml-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-neon-lime"
                 >
                   ✓ Mark explored
                 </button>

--- a/src/components/project/dashboard/dashboard-insights-grid.tsx
+++ b/src/components/project/dashboard/dashboard-insights-grid.tsx
@@ -34,7 +34,8 @@ export function DashboardInsightsGrid({
                 <div className="flex gap-2 mt-2">
                   <button
                     onClick={() => onResolveTangent(tangent.id)}
-                    className="text-xs text-green-400 hover:text-green-300"
+                    aria-label={`Resolve dropped thread: ${tangent.thread}`}
+                    className="text-xs text-green-400 hover:text-green-300 transition-colors rounded px-1 -ml-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-400"
                   >
                     ✓ Resolved
                   </button>
@@ -70,7 +71,8 @@ export function DashboardInsightsGrid({
                 )}
                 <button
                   onClick={() => onResolveGap(gap.id)}
-                  className="text-xs text-green-400 hover:text-green-300 mt-2"
+                  aria-label={`Resolve gap: ${gap.description.slice(0, 30)}...`}
+                  className="text-xs text-green-400 hover:text-green-300 mt-2 transition-colors rounded px-1 -ml-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-400"
                 >
                   ✓ Resolved
                 </button>

--- a/src/components/project/dashboard/dashboard-search-card.tsx
+++ b/src/components/project/dashboard/dashboard-search-card.tsx
@@ -29,13 +29,13 @@ export function DashboardSearchCard({
           aria-label="Search project content"
           aria-busy={searching}
           placeholder="Search sessions, docs, concepts, questions..."
-          className="flex-1 bg-gray-800 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500"
+          className="flex-1 bg-gray-800 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 transition-colors focus-visible:outline-none focus-visible:border-indigo-500 focus-visible:ring-1 focus-visible:ring-indigo-500"
         />
         <button
           onClick={onSearch}
           disabled={searching}
           aria-busy={searching}
-          className="rounded bg-indigo-600 px-4 py-2 text-sm text-white disabled:cursor-not-allowed disabled:opacity-60 hover:bg-indigo-700"
+          className="rounded bg-indigo-600 px-4 py-2 text-sm text-white disabled:cursor-not-allowed disabled:opacity-60 hover:bg-indigo-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-1 focus-visible:ring-offset-gray-900"
         >
           {searching ? 'Searching...' : 'Search'}
         </button>

--- a/src/lib/server/routes/transcribe.ts
+++ b/src/lib/server/routes/transcribe.ts
@@ -1,4 +1,5 @@
 import { badRequest } from '@/lib/server/errors';
+import { File } from 'node:buffer';
 
 const MAX_AUDIO_BYTES = 15 * 1024 * 1024;
 const MAX_AUDIO_MB = Math.floor(MAX_AUDIO_BYTES / (1024 * 1024));


### PR DESCRIPTION
💡 What: Added contextual `aria-label`s to repeating inline list action buttons ("✓ Approve", "✓ Resolved") and added `focus-visible` ring styles to list buttons and search components. Created a journal entry.
🎯 Why: Screen reader users previously heard indistinguishable repeating labels for inline actions. Keyboard navigators lacked clear visual indicators of which item they were focused on.
♿ Accessibility: Improved screen reader clarity for dynamic list items and added visible focus rings for keyboard navigation.

---
*PR created automatically by Jules for task [243462020416869774](https://jules.google.com/task/243462020416869774) started by @Phazzie*

## Summary by Sourcery

Improve accessibility of dashboard inline actions and search.

New Features:
- Add contextual aria-labels to dashboard list action buttons for screen reader clarity.

Enhancements:
- Add visible focus rings and padding adjustments to dashboard list buttons and search inputs for better keyboard navigation.

Documentation:
- Add a Palette journal entry documenting ARIA labeling and focus ring patterns for inline list buttons.