### PR TITLE
🎨 Palette: Micro-UX Accessibility Improvements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-07 - Component specific focus states and ARIA semantics
+**Learning:** For Next.js projects relying strictly on Tailwind CSS, standard accessible HTML structures (like accordion buttons and icon-only buttons) sometimes lack base styles for keyboard focus visibility and accessible names.
+**Action:** When adding ARIA properties like `aria-controls` and `aria-expanded` for dynamic UI blocks, always complement them with `focus-visible:ring-*` classes to ensure full keyboard navigation support, and always use `aria-label` for buttons rendering only emojis or SVG marks.

--- a/src/app/api/__tests__/route-handlers.contract.test.ts
+++ b/src/app/api/__tests__/route-handlers.contract.test.ts
@@ -6,7 +6,13 @@ import { POST as transcribePOST } from '@/app/api/transcribe/route';
 import { GET as sessionsGET, POST as sessionsPOST } from '@/app/api/projects/[id]/sessions/route';
 import { GET as documentsGET, POST as documentsPOST } from '@/app/api/projects/[id]/documents/route';
 import { POST as exportPOST } from '@/app/api/projects/[id]/export/route';
+import { File as NodeFile } from 'node:buffer';
 import { GET as healthGET } from '@/app/api/health/route';
+
+if (typeof globalThis.File === 'undefined') {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  globalThis.File = NodeFile as any;
+}
 
 test('auth/register returns 400 error shape for malformed JSON', async () => {
   const response = await registerPOST(new Request('http://localhost/api/auth/register', {

--- a/src/app/api/__tests__/transcribe.contract.test.ts
+++ b/src/app/api/__tests__/transcribe.contract.test.ts
@@ -1,8 +1,14 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { File as NodeFile } from 'node:buffer';
 import { handleRoute } from '@/lib/server/http';
 import { AppError, badRequest } from '@/lib/server/errors';
 import { parseTranscribeRequest, validateTranscribeAudioFile, ALLOWED_AUDIO_MIME_TYPES } from '@/lib/server/routes/transcribe';
+
+if (typeof globalThis.File === 'undefined') {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  globalThis.File = NodeFile as any;
+}
 
 function normalizeQuestionId(value: FormDataEntryValue | null) {
   return typeof value === 'string' && value ? value : undefined;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -290,14 +290,14 @@ export default function HomePage() {
                         <button
                           onClick={(e) => startRename(project, e)}
                           aria-label={`Rename ${project.name}`}
-                          className="rounded-lg p-1.5 text-app-fg-muted transition hover:bg-app-surface-strong hover:text-white"
+                          className="rounded-lg p-1.5 text-app-fg-muted transition hover:bg-app-surface-strong hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
                         >
                           ✏️
                         </button>
                         <button
                           onClick={(e) => startDelete(project.id, e)}
                           aria-label={`Delete ${project.name}`}
-                          className="rounded-lg p-1.5 text-app-fg-muted transition hover:bg-red-900/30 hover:text-red-400"
+                          className="rounded-lg p-1.5 text-app-fg-muted transition hover:bg-red-900/30 hover:text-red-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
                         >
                           🗑️
                         </button>

--- a/src/app/project/[id]/export/page.tsx
+++ b/src/app/project/[id]/export/page.tsx
@@ -132,14 +132,16 @@ export default function ExportPage() {
         </GlassCard>
 
         {/* Export level selector */}
-        <div className="mb-6 space-y-2.5">
+        <div className="mb-6 space-y-2.5" role="radiogroup" aria-label="Export Level">
           {exportLevels.map((level) => {
             const active = exportLevel === level.value;
             return (
               <button
                 key={level.value}
+                role="radio"
+                aria-checked={active}
                 onClick={() => setExportLevel(level.value)}
-                className={`w-full rounded-2xl border p-5 text-left transition-all duration-150 ${
+                className={`w-full rounded-2xl border p-5 text-left transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-purple ${
                   active
                     ? 'border-neon-purple/50 bg-neon-purple-dim glow-purple'
                     : 'border-app-border bg-app-surface hover:border-app-border-strong hover:bg-app-surface-muted'

--- a/src/app/project/[id]/record/page.tsx
+++ b/src/app/project/[id]/record/page.tsx
@@ -57,7 +57,8 @@ function RecordingControlCard({
   return (
     <Card className="mb-6 text-center">
       <button
-        className={`mx-auto mb-6 flex h-24 w-24 items-center justify-center rounded-full transition-all ${
+        aria-label={state === 'recording' ? 'Stop recording' : 'Start recording'}
+        className={`mx-auto mb-6 flex h-24 w-24 items-center justify-center rounded-full transition-all focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-white/50 ${
           state === 'recording'
             ? 'recording-pulse bg-red-600 shadow-lg shadow-red-900'
             : 'bg-app-accent hover:brightness-110'

--- a/src/app/project/[id]/sessions/page.tsx
+++ b/src/app/project/[id]/sessions/page.tsx
@@ -68,19 +68,21 @@ export default function SessionsPage() {
                 <Card key={session.id} className="overflow-hidden p-0">
                   <button
                     onClick={() => setExpandedId(expandedId === session.id ? null : session.id)}
-                    className="w-full px-5 py-4 text-left transition hover:bg-app-surface-muted"
+                    aria-expanded={expandedId === session.id}
+                    aria-controls={`session-content-${session.id}`}
+                    className="w-full px-5 py-4 text-left transition hover:bg-app-surface-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-app-accent"
                   >
                     <div className="flex items-center justify-between gap-3">
                       <div>
                         <p className="font-medium text-white">Session — {new Date(session.createdAt).toLocaleString()}</p>
                         <p className="mt-0.5 text-sm text-app-fg-muted">{session.transcript.slice(0, 100)}...</p>
                       </div>
-                      <span className="text-app-fg-muted">{expandedId === session.id ? '▲' : '▼'}</span>
+                      <span className="text-app-fg-muted" aria-hidden="true">{expandedId === session.id ? '▲' : '▼'}</span>
                     </div>
                   </button>
 
                   {expandedId === session.id && (
-                    <div className="border-t border-app-border px-5 py-4">
+                    <div id={`session-content-${session.id}`} className="border-t border-app-border px-5 py-4">
                       <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-app-fg-muted">Raw Transcript</h3>
                       <p className="whitespace-pre-wrap text-sm leading-relaxed text-app-fg">{session.transcript}</p>
 


### PR DESCRIPTION
# 🎨 Palette: Micro-UX Accessibility Improvements

## 💡 What
- **Sessions Page:** Added `aria-expanded` and `aria-controls` to the session toggle buttons to provide screen readers context on what is being expanded.
- **Export Page:** Converted the custom list of export buttons into a semantic radio group by adding `role="radiogroup"` to the container and `role="radio"`, `aria-checked` to the buttons.
- **Global / Record / Home Page:** Added clear focus-visible rings using Tailwind's `focus-visible:ring-*` utilities to the microphone record button and the icon-only (✏️ and 🗑️) rename and delete buttons. Added an explicit `aria-label` to the record button.

## 🎯 Why
- Screen readers previously did not announce the expansion state of a session or what content the button controlled.
- The export level selector visually behaves like a radio button group but lacked the semantic markup for screen readers to recognize it as such.
- Keyboard users could not clearly see which icon-only button had focus when tabbing through the interface.

## ♿ Accessibility
- Full keyboard navigation support with explicit, visible focus states on previously ambiguous custom buttons.
- Semantic ARIA roles applied where native HTML elements were insufficient to describe custom UI behavior (like expanding regions and custom radio options).

---
*PR created automatically by Jules for task [16726000297553816567](https://jules.google.com/task/16726000297553816567) started by @Phazzie*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated focus styling for interactive buttons across project management, export, recording, and session pages.
  * Enhanced button components with improved visual feedback indicators.

* **Documentation**
  * Added accessibility guidelines documentation to the design reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->