### PR TITLE
🎨 Palette: Improve accessibility for inline action buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-11 - Dynamic ARIA labels for repeating inline actions
+**Learning:** In grids or lists with repeating items (like "Approve", "Resolved", "Mark explored"), generic ARIA labels are insufficient for screen readers. Using dynamic values (e.g., `Approve concept: ${concept.name}`) provides essential context. Also, inline elements like `button` without standard button classes often lack focus states.
+**Action:** Always map dynamic content properties to the `aria-label` for repeating inline buttons and explicitly add `focus-visible` utility classes to ensure keyboard accessibility.

--- a/src/app/api/__tests__/transcribe.contract.test.ts
+++ b/src/app/api/__tests__/transcribe.contract.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { handleRoute } from '@/lib/server/http';
 import { AppError, badRequest } from '@/lib/server/errors';
 import { parseTranscribeRequest, validateTranscribeAudioFile, ALLOWED_AUDIO_MIME_TYPES } from '@/lib/server/routes/transcribe';
+import { File } from 'buffer';
 
 function normalizeQuestionId(value: FormDataEntryValue | null) {
   return typeof value === 'string' && value ? value : undefined;

--- a/src/app/project/[id]/record/page.tsx
+++ b/src/app/project/[id]/record/page.tsx
@@ -57,7 +57,8 @@ function RecordingControlCard({
   return (
     <Card className="mb-6 text-center">
       <button
-        className={`mx-auto mb-6 flex h-24 w-24 items-center justify-center rounded-full transition-all ${
+        aria-label={state === 'recording' ? 'Stop recording' : 'Start recording'}
+        className={`mx-auto mb-6 flex h-24 w-24 items-center justify-center rounded-full transition-all focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-neon-lime ${
           state === 'recording'
             ? 'recording-pulse bg-red-600 shadow-lg shadow-red-900'
             : 'bg-app-accent hover:brightness-110'

--- a/src/components/project/dashboard/dashboard-concepts-contradictions.tsx
+++ b/src/components/project/dashboard/dashboard-concepts-contradictions.tsx
@@ -23,7 +23,8 @@ export function DashboardConceptsContradictions({
                 <p className="text-xs text-app-fg-muted mt-1">{concept.definition}</p>
                 <button
                   onClick={() => onApproveConcept(concept.id)}
-                  className="text-xs text-neon-lime/70 hover:text-neon-lime mt-2 transition-colors"
+                  aria-label={`Approve concept: ${concept.name}`}
+                  className="text-xs text-neon-lime/70 hover:text-neon-lime mt-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-lime focus-visible:rounded"
                 >
                   ✓ Approve
                 </button>
@@ -48,7 +49,8 @@ export function DashboardConceptsContradictions({
                 <p className="text-sm text-neon-pink">{item.description}</p>
                 <button
                   onClick={() => onMarkContradictionExplored(item.id)}
-                  className="text-xs text-neon-lime/70 hover:text-neon-lime mt-2 transition-colors"
+                  aria-label={`Mark contradiction explored: ${item.description}`}
+                  className="text-xs text-neon-lime/70 hover:text-neon-lime mt-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-lime focus-visible:rounded"
                 >
                   ✓ Mark explored
                 </button>

--- a/src/components/project/dashboard/dashboard-insights-grid.tsx
+++ b/src/components/project/dashboard/dashboard-insights-grid.tsx
@@ -34,7 +34,8 @@ export function DashboardInsightsGrid({
                 <div className="flex gap-2 mt-2">
                   <button
                     onClick={() => onResolveTangent(tangent.id)}
-                    className="text-xs text-green-400 hover:text-green-300"
+                    aria-label={`Resolve dropped thread: ${tangent.thread}`}
+                    className="text-xs text-green-400 hover:text-green-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:rounded"
                   >
                     ✓ Resolved
                   </button>
@@ -70,7 +71,8 @@ export function DashboardInsightsGrid({
                 )}
                 <button
                   onClick={() => onResolveGap(gap.id)}
-                  className="text-xs text-green-400 hover:text-green-300 mt-2"
+                  aria-label={`Resolve gap: ${gap.description}`}
+                  className="text-xs text-green-400 hover:text-green-300 mt-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:rounded"
                 >
                   ✓ Resolved
                 </button>


### PR DESCRIPTION
💡 What: Added dynamic `aria-label` attributes and explicit `focus-visible` utility classes to repeating inline action buttons across the dashboard and record page. Also documented this learning in `.Jules/palette.md`.
🎯 Why: Repeating inline buttons (like "Approve" or "Resolved") were indistinguishable to screen readers without context, and lacking standard button classes meant they had no keyboard focus indicators. This improves accessibility and keyboard navigation.
📸 Before/After: Visual changes apply only when focusing via keyboard or when using screen reader. Verified changes successfully in playwright.
♿ Accessibility:
- Dynamic ARIA labels give specific context for each item in a map/list.
- Added explicit keyboard focus rings using existing design tokens.
- Addressed record button missing text/label.

---
*PR created automatically by Jules for task [7008720112926454987](https://jules.google.com/task/7008720112926454987) started by @Phazzie*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced keyboard navigation with improved visual focus indicators on action buttons throughout the application.
  * Added dynamic descriptive labels to buttons for improved screen reader accessibility.

* **Documentation**
  * Added accessibility best practices documenting focus styling and aria-label patterns for inline actions in grids and lists.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Phazzie/SkepticalWombatTellsYourTale/pull/155)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->