### PR TITLE
🎨 Palette: Dashboard accessibility improvements (ARIA labels & focus states)

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-18 - Dynamic ARIA labels for repeating inline actions
+**Learning:** In dashboard grids with multiple identical action buttons (e.g. "Approve", "Resolved"), generic `aria-label`s fail to provide context for screen reader users navigating out of context.
+**Action:** Always append the context-specific item name or identifier to the `aria-label` (e.g. `aria-label={"Approve concept: ${concept.name}"}`) for repeating interactive elements within a grid or list.

--- a/src/components/project/dashboard/dashboard-concepts-contradictions.tsx
+++ b/src/components/project/dashboard/dashboard-concepts-contradictions.tsx
@@ -23,13 +23,14 @@ export function DashboardConceptsContradictions({
                 <p className="text-xs text-app-fg-muted mt-1">{concept.definition}</p>
                 <button
                   onClick={() => onApproveConcept(concept.id)}
-                  className="text-xs text-neon-lime/70 hover:text-neon-lime mt-2 transition-colors"
+                  aria-label={`Approve concept: ${concept.name}`}
+                  className="text-xs text-neon-lime/70 hover:text-neon-lime mt-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-lime rounded"
                 >
                   ✓ Approve
                 </button>
               </div>
             ))}
-            <Link href={`/project/${id}/concepts`} className="text-xs text-app-fg-muted hover:text-neon-lime transition-colors">
+            <Link href={`/project/${id}/concepts`} className="text-xs text-app-fg-muted hover:text-neon-lime transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-lime rounded">
               View all →
             </Link>
           </div>
@@ -48,13 +49,14 @@ export function DashboardConceptsContradictions({
                 <p className="text-sm text-neon-pink">{item.description}</p>
                 <button
                   onClick={() => onMarkContradictionExplored(item.id)}
-                  className="text-xs text-neon-lime/70 hover:text-neon-lime mt-2 transition-colors"
+                  aria-label={`Mark contradiction explored: ${item.description}`}
+                  className="text-xs text-neon-lime/70 hover:text-neon-lime mt-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-lime rounded"
                 >
                   ✓ Mark explored
                 </button>
               </div>
             ))}
-            <Link href={`/project/${id}/contradictions`} className="text-xs text-app-fg-muted hover:text-neon-lime transition-colors">
+            <Link href={`/project/${id}/contradictions`} className="text-xs text-app-fg-muted hover:text-neon-lime transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-lime rounded">
               View all →
             </Link>
           </div>

--- a/src/components/project/dashboard/dashboard-insights-grid.tsx
+++ b/src/components/project/dashboard/dashboard-insights-grid.tsx
@@ -34,14 +34,15 @@ export function DashboardInsightsGrid({
                 <div className="flex gap-2 mt-2">
                   <button
                     onClick={() => onResolveTangent(tangent.id)}
-                    className="text-xs text-green-400 hover:text-green-300"
+                    aria-label={`Resolve dropped thread: ${tangent.thread}`}
+                    className="text-xs text-green-400 hover:text-green-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-400 rounded"
                   >
                     ✓ Resolved
                   </button>
                 </div>
               </div>
             ))}
-            <Link href={`/project/${id}/tangents`} className="text-xs text-indigo-400 hover:text-indigo-300">
+            <Link href={`/project/${id}/tangents`} className="text-xs text-indigo-400 hover:text-indigo-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 rounded">
               View all tangents →
             </Link>
           </div>
@@ -70,13 +71,14 @@ export function DashboardInsightsGrid({
                 )}
                 <button
                   onClick={() => onResolveGap(gap.id)}
-                  className="text-xs text-green-400 hover:text-green-300 mt-2"
+                  aria-label={`Resolve gap: ${gap.description}`}
+                  className="text-xs text-green-400 hover:text-green-300 mt-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-400 rounded"
                 >
                   ✓ Resolved
                 </button>
               </div>
             ))}
-            <Link href={`/project/${id}/gaps`} className="text-xs text-indigo-400 hover:text-indigo-300">
+            <Link href={`/project/${id}/gaps`} className="text-xs text-indigo-400 hover:text-indigo-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 rounded">
               View all gaps →
             </Link>
           </div>
@@ -105,7 +107,7 @@ export function DashboardInsightsGrid({
                 </p>
               </div>
             ))}
-            <Link href={`/project/${id}/patterns`} className="text-xs text-indigo-400 hover:text-indigo-300">
+            <Link href={`/project/${id}/patterns`} className="text-xs text-indigo-400 hover:text-indigo-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 rounded">
               View all patterns →
             </Link>
           </div>

--- a/src/components/project/dashboard/dashboard-search-card.tsx
+++ b/src/components/project/dashboard/dashboard-search-card.tsx
@@ -29,13 +29,13 @@ export function DashboardSearchCard({
           aria-label="Search project content"
           aria-busy={searching}
           placeholder="Search sessions, docs, concepts, questions..."
-          className="flex-1 bg-gray-800 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500"
+          className="flex-1 bg-gray-800 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:border-transparent"
         />
         <button
           onClick={onSearch}
           disabled={searching}
           aria-busy={searching}
-          className="rounded bg-indigo-600 px-4 py-2 text-sm text-white disabled:cursor-not-allowed disabled:opacity-60 hover:bg-indigo-700"
+          className="rounded bg-indigo-600 px-4 py-2 text-sm text-white disabled:cursor-not-allowed disabled:opacity-60 hover:bg-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
         >
           {searching ? 'Searching...' : 'Search'}
         </button>


### PR DESCRIPTION
### 💡 What: 
Added contextual `aria-label` attributes to ambiguous action buttons (e.g., "Approve" becomes "Approve concept: [Name]") and explicit keyboard focus states (`focus-visible:ring`) to interactive elements across three dashboard components (`dashboard-concepts-contradictions`, `dashboard-insights-grid`, `dashboard-search-card`).

### 🎯 Why: 
To improve accessibility. Previously, screen reader users would encounter multiple buttons simply labeled "Approve" without knowing which concept it applied to. Keyboard users also lacked clear visual feedback when tabbing through the interface, making navigation difficult.

### ♿ Accessibility: 
- Fixed missing context for screen readers on repeating inline action buttons.
- Ensure clear visual focus rings for keyboard navigation.

---
*PR created automatically by Jules for task [13380630266298788945](https://jules.google.com/task/13380630266298788945) started by @Phazzie*

## Summary by Sourcery

Improve accessibility of dashboard interactions by adding contextual ARIA labels and visible keyboard focus states.

Bug Fixes:
- Provide contextual ARIA labels for repeated inline action buttons in dashboard lists and grids.

Enhancements:
- Add consistent focus-visible ring styles to buttons and links across dashboard insights, concepts, contradictions, and search components.
- Document accessibility learning around dynamic ARIA labels for repeating inline actions in the Palette notes.