### PR TITLE
Unify project pages with shared UI primitives

### DIFF
--- a/src/app/project/[id]/documents/page.tsx
+++ b/src/app/project/[id]/documents/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import { useParams } from 'next/navigation';
-import Link from 'next/link';
+import { AppHeader } from '@/components/layout/app-header';
+import { AppBackLink, Card, Container, PrimaryButton, SecondaryButton, Shell, StatusMessage, TextArea, TextInput } from '@/components/ui/primitives';
 import { Document } from '@/lib/types';
 import { requestJson } from '@/lib/client/request';
 
@@ -114,88 +115,77 @@ export default function DocumentsPage() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gray-950 flex items-center justify-center">
-        <div className="text-gray-500">Loading documents...</div>
-      </div>
+      <Shell>
+        <Container wide>
+          <StatusMessage state="loading" title="Loading documents..." />
+        </Container>
+      </Shell>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gray-950 text-gray-100">
-      <div className="max-w-5xl mx-auto px-6 py-8">
-        <div className="flex items-center gap-4 mb-6">
-          <Link href={`/project/${id}`} className="text-gray-500 hover:text-gray-300 text-sm">
-            ← Back
-          </Link>
-          <h1 className="text-2xl font-bold">Documents</h1>
-          <button
-            onClick={() => setShowNew(true)}
-            className="ml-auto bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-lg text-sm font-medium"
-          >
-            + New Document
-          </button>
-        </div>
+    <Shell>
+      <Container wide>
+        <AppBackLink href={`/project/${id}`} />
+        <div className="mt-4" />
+        <AppHeader
+          title="Documents"
+          actions={<PrimaryButton onClick={() => setShowNew(true)}>+ New Document</PrimaryButton>}
+        />
         {actionError && (
-          <div
-            role="alert"
-            aria-live="assertive"
-            className="mb-6 rounded-xl border border-red-700 bg-red-900/20 p-4 text-sm text-red-300"
-          >
-            {actionError}
+          <div role="alert" aria-live="assertive" className="mb-6">
+            <StatusMessage state="error" title={actionError} />
           </div>
         )}
 
         {showNew && (
-          <div className="bg-gray-900 border border-gray-700 rounded-xl p-5 mb-6">
-            <h3 className="font-semibold mb-3">New Document</h3>
-            <input
+          <Card className="mb-6">
+            <h3 className="mb-3 font-semibold text-app-fg">New Document</h3>
+            <TextInput
               type="text"
               placeholder="Document name..."
               value={newName}
               onChange={(e) => setNewName(e.target.value)}
-              className="w-full bg-gray-800 border border-gray-600 rounded-lg px-4 py-2 mb-3 text-white placeholder-gray-500 focus:outline-none focus:border-indigo-500"
+              className="mb-3"
               autoFocus
             />
             <select
               value={newType}
               onChange={(e) => setNewType(e.target.value)}
-              className="w-full bg-gray-800 border border-gray-600 rounded-lg px-4 py-2 mb-4 text-white focus:outline-none focus:border-indigo-500"
+              className="mb-4 w-full rounded-xl border border-app-border bg-app-surface-muted px-4 py-2.5 text-sm text-app-fg transition focus-visible:border-neon-lime/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-lime"
             >
               {documentTypes.map((t) => (
                 <option key={t} value={t}>{t.charAt(0).toUpperCase() + t.slice(1)}</option>
               ))}
             </select>
             <div className="flex gap-3">
-              <button onClick={createDocument} className="bg-indigo-600 hover:bg-indigo-700 text-white px-6 py-2 rounded-lg font-medium">
+              <PrimaryButton onClick={createDocument} className="px-6">
                 Create
-              </button>
-              <button onClick={() => setShowNew(false)} className="bg-gray-700 hover:bg-gray-600 text-white px-6 py-2 rounded-lg font-medium">
+              </PrimaryButton>
+              <SecondaryButton onClick={() => setShowNew(false)} className="px-6">
                 Cancel
-              </button>
+              </SecondaryButton>
             </div>
-          </div>
+          </Card>
         )}
 
         {documents.length === 0 ? (
-          <div className="text-center py-16 text-gray-500">
-            <div className="text-5xl mb-4">📄</div>
-            <p>No documents yet. Create your first working document.</p>
-          </div>
+          <StatusMessage state="empty" title="No documents yet." description="Create your first working document." />
         ) : (
           <div className="space-y-4">
             {documents.map((doc) => (
-              <div key={doc.id} className="bg-gray-900 border border-gray-700 rounded-xl overflow-hidden">
-                <div className="flex items-center justify-between px-5 py-4 border-b border-gray-700">
+              <Card key={doc.id} className="overflow-hidden p-0">
+                <div className="flex items-center justify-between gap-3 border-b border-app-border px-5 py-4">
                   <div>
-                    <span className="font-semibold text-white">{doc.name}</span>
-                    <span className="ml-2 text-xs text-gray-500 bg-gray-800 px-2 py-0.5 rounded">{doc.type}</span>
+                    <span className="font-semibold text-app-fg">{doc.name}</span>
+                    <span className="ml-2 rounded bg-app-surface-muted px-2 py-0.5 text-xs text-app-fg-muted">{doc.type}</span>
                   </div>
                   <button
                     onClick={() => {
                       setEditingId(editingId === doc.id ? null : doc.id);
                       setEditContent(doc.content);
                     }}
-                    className="text-sm text-indigo-400 hover:text-indigo-300"
+                    className="text-sm text-neon-lime transition hover:text-neon-lime/80"
                   >
                     {editingId === doc.id ? 'Cancel' : 'Edit'}
                   </button>
@@ -203,26 +193,26 @@ export default function DocumentsPage() {
 
                 {editingId === doc.id ? (
                   <div className="p-5">
-                    <textarea
+                    <TextArea
                       value={editContent}
                       onChange={(e) => setEditContent(e.target.value)}
                       rows={12}
-                      className="w-full bg-gray-800 border border-gray-600 rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:border-indigo-500 resize-none font-mono text-sm"
+                      className="resize-none font-mono"
                       placeholder="Document content..."
                     />
-                    <div className="mt-4 p-4 bg-gray-800 rounded-lg">
-                      <p className="text-xs text-green-400 mb-2">✍️ Generate in your voice</p>
-                      <input
+                    <div className="mt-4 rounded-xl border border-app-border bg-app-surface-muted p-4">
+                      <p className="mb-2 text-xs text-neon-lime">✍️ Generate in your voice</p>
+                      <TextInput
                         type="text"
                         placeholder="What do you want written? (e.g., 'the story about my father')"
                         value={voicePrompt}
                         onChange={(e) => setVoicePrompt(e.target.value)}
-                        className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none mb-2"
+                        className="mb-2"
                       />
                       <button
                         onClick={() => generateDraft(doc.id)}
                         disabled={generatingDraft || !voicePrompt.trim()}
-                        className="text-xs bg-green-700 hover:bg-green-600 disabled:opacity-50 text-white px-4 py-1.5 rounded"
+                        className="rounded-lg border border-neon-lime/30 bg-neon-lime-dim px-4 py-1.5 text-xs font-medium text-neon-lime transition hover:border-neon-lime disabled:opacity-50"
                       >
                         {generatingDraft ? 'Writing in your voice...' : 'Generate Draft'}
                       </button>
@@ -230,44 +220,44 @@ export default function DocumentsPage() {
                         <div
                           className={`mt-3 border rounded p-3 text-xs ${
                             driftFeedback.hasDrift
-                              ? 'border-amber-700 bg-amber-900/20 text-amber-300'
-                              : 'border-green-700 bg-green-900/20 text-green-300'
+                              ? 'border-neon-purple-border bg-neon-purple-dim text-neon-purple'
+                              : 'border-neon-lime-border bg-neon-lime-dim text-neon-lime'
                           }`}
                         >
                           <p>{driftFeedback.hasDrift ? 'Voice drift detected.' : 'Voice match looks strong.'}</p>
-                          {driftFeedback.details && <p className="mt-1 text-gray-300">{driftFeedback.details}</p>}
+                          {driftFeedback.details && <p className="mt-1 text-app-fg">{driftFeedback.details}</p>}
                           {driftFeedback.rewriteSuggestion && (
-                            <p className="mt-1 text-gray-400">Suggestion: {driftFeedback.rewriteSuggestion}</p>
+                            <p className="mt-1 text-app-fg-muted">Suggestion: {driftFeedback.rewriteSuggestion}</p>
                           )}
                         </div>
                       )}
                     </div>
                     <div className="flex gap-3 mt-3">
-                      <button
+                      <PrimaryButton
                         onClick={() => saveDocument(doc.id)}
                         disabled={saving}
-                        className="bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white px-6 py-2 rounded-lg font-medium text-sm"
+                        className="px-6"
                       >
                         {saving ? 'Saving...' : 'Save'}
-                      </button>
+                      </PrimaryButton>
                     </div>
                   </div>
                 ) : (
                   <div className="px-5 py-4">
                     {doc.content ? (
-                      <p className="text-gray-300 text-sm leading-relaxed whitespace-pre-wrap line-clamp-6">
+                      <p className="line-clamp-6 whitespace-pre-wrap text-sm leading-relaxed text-app-fg">
                         {doc.content}
                       </p>
                     ) : (
-                      <p className="text-gray-600 text-sm italic">Empty document</p>
+                      <p className="text-sm italic text-app-fg-muted">Empty document</p>
                     )}
                   </div>
                 )}
-              </div>
+              </Card>
             ))}
           </div>
         )}
-      </div>
-    </div>
+      </Container>
+    </Shell>
   );
 }

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -90,7 +90,7 @@ export default function ProjectPage() {
         <div className="mt-4" />
 
         {showRename ? (
-          <Card className="mb-6 border-indigo-700">
+          <Card className="mb-6 border-neon-lime-border">
             <h3 className="text-sm font-semibold text-app-fg-muted mb-3">Rename project</h3>
             <TextInput
               type="text"
@@ -112,7 +112,7 @@ export default function ProjectPage() {
               rows={2}
               className="mb-4 resize-none"
             />
-            {renameError && <p className="text-sm text-red-400 mb-3">{renameError}</p>}
+            {renameError && <p className="mb-3 text-sm text-neon-pink">{renameError}</p>}
             <div className="flex gap-3">
               <PrimaryButton onClick={submitRename} disabled={renaming || !renameValue.trim()}>
                 {renaming ? 'Saving...' : 'Save'}
@@ -137,7 +137,7 @@ export default function ProjectPage() {
 
         {actionError && (
           <div role="alert">
-            <Card className="mb-6 border-red-700 bg-red-900/20 text-sm text-red-300">
+            <Card className="mb-6 border-neon-pink-border bg-neon-pink-dim text-sm text-neon-pink">
               {actionError}
             </Card>
           </div>

--- a/src/app/project/[id]/questions/page.tsx
+++ b/src/app/project/[id]/questions/page.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useParams } from 'next/navigation';
 import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { AppHeader } from '@/components/layout/app-header';
+import { AppBackLink, Card, Container, PrimaryButton, SecondaryButton, Shell, StatusMessage } from '@/components/ui/primitives';
 import { Question, QuestionGenerationPayload } from '@/lib/types';
 import { toneCopy } from '@/lib/copy/tone';
 import { requestJson } from '@/lib/client/request';
@@ -84,87 +86,78 @@ export default function QuestionsPage() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gray-950 flex items-center justify-center">
-        <div className="text-gray-500">Loading questions...</div>
-      </div>
+      <Shell>
+        <Container>
+          <StatusMessage state="loading" title="Loading questions..." />
+        </Container>
+      </Shell>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gray-950 text-gray-100">
-      <div className="max-w-3xl mx-auto px-6 py-8">
-        <div className="flex items-center gap-4 mb-6">
-          <Link href={`/project/${id}`} className="text-gray-500 hover:text-gray-300 text-sm">
-            ← Back
-          </Link>
-          <h1 className="text-2xl font-bold">Questions</h1>
-          <button
-            onClick={generateQuestions}
-            disabled={generating}
-            className="ml-auto bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white px-4 py-2 rounded-lg text-sm font-medium"
-          >
-            {generating ? 'Generating...' : '+ Generate More'}
-          </button>
-        </div>
+    <Shell>
+      <Container>
+        <AppBackLink href={`/project/${id}`} />
+        <div className="mt-4" />
+        <AppHeader
+          title="Questions"
+          actions={(
+            <PrimaryButton onClick={generateQuestions} disabled={generating}>
+              {generating ? 'Generating...' : '+ Generate More'}
+            </PrimaryButton>
+          )}
+        />
 
-        <div className="bg-gray-900 border border-gray-700 rounded-xl p-5 mb-6">
-            <p className="text-gray-400 text-sm">
-              {toneCopy.questionsIntro}
-            </p>
-          <div className="flex gap-2 mt-3">
+        <Card className="mb-6">
+          <p className="text-sm text-app-fg-muted">{toneCopy.questionsIntro}</p>
+          <div className="mt-3 flex flex-wrap gap-2">
             {(['all', 'pending', 'answered', 'dismissed'] as const).map((filter) => (
-              <button
+              <SecondaryButton
                 key={filter}
                 onClick={() => setActiveFilter(filter)}
-                className={`text-xs px-3 py-1 rounded-full border ${
+                className={`rounded-full px-3 py-1 text-xs ${
                   activeFilter === filter
-                    ? 'bg-indigo-600 border-indigo-500 text-white'
-                    : 'bg-gray-800 border-gray-700 text-gray-300'
+                    ? 'border-neon-lime bg-neon-lime-dim text-neon-lime'
+                    : ''
                 }`}
               >
                 {filter}
-              </button>
+              </SecondaryButton>
             ))}
           </div>
-        </div>
+        </Card>
 
         {generationIssue && (
-          <div className="mb-6 rounded-xl border border-amber-700 bg-amber-900/20 p-4 text-sm text-amber-300">
-            {generationIssue}
+          <div className="mb-6">
+            <StatusMessage state="error" title={generationIssue} />
           </div>
         )}
 
         {questions.length === 0 ? (
-          <div className="text-center py-16 text-gray-500">
-            <div className="text-5xl mb-4">❓</div>
-            <p>{toneCopy.questionsEmpty}</p>
-            <button onClick={generateQuestions} className="text-indigo-400 hover:text-indigo-300 mt-2">
-              Generate questions from your material →
-            </button>
-          </div>
+          <StatusMessage state="empty" title={toneCopy.questionsEmpty} description="Generate questions from your material when you are ready." />
         ) : (
           <div className="space-y-3">
             {questions.map((q, i) => (
-              <div key={i} className="bg-gray-900 border border-gray-700 rounded-xl p-4 flex items-start gap-4">
-                <span className="text-gray-600 text-sm mt-0.5 font-mono w-6">{i + 1}.</span>
+              <Card key={q.id} className="flex flex-col gap-4 sm:flex-row sm:items-start">
+                <span className="font-mono text-sm text-app-fg-muted sm:w-6">{i + 1}.</span>
                 <div className="flex-1">
-                  <p className="text-gray-200">{q.text}</p>
-                  <p className="text-xs text-gray-500 mt-1">Status: {q.status}</p>
+                  <p className="text-app-fg">{q.text}</p>
+                  <p className="mt-1 text-xs text-app-fg-muted">Status: {q.status}</p>
                   {q.sessionRef && (
-                    <p className="text-xs text-gray-600 mt-1">From session {q.sessionRef.slice(0, 8)}...</p>
+                    <p className="mt-1 text-xs text-app-fg-muted">From session {q.sessionRef.slice(0, 8)}...</p>
                   )}
                 </div>
-                <div className="flex flex-col items-end gap-2">
+                <div className="flex shrink-0 flex-wrap gap-3 sm:flex-col sm:items-end sm:gap-2">
                   <Link
                     href={`/project/${id}/record?questionId=${q.id}`}
-                    className="text-xs text-indigo-400 hover:text-indigo-300 shrink-0"
+                    className="text-xs text-neon-lime transition hover:text-neon-lime/80"
                   >
                     Answer →
                   </Link>
                   {q.status !== 'dismissed' && (
                     <button
                       onClick={() => setQuestionStatus(q.id, 'dismissed')}
-                      className="text-[11px] text-gray-500 hover:text-gray-300"
+                      className="text-[11px] text-app-fg-muted transition hover:text-app-fg"
                     >
                       Dismiss
                     </button>
@@ -172,17 +165,17 @@ export default function QuestionsPage() {
                   {q.status !== 'pending' && (
                     <button
                       onClick={() => setQuestionStatus(q.id, 'pending')}
-                      className="text-[11px] text-gray-500 hover:text-gray-300"
+                      className="text-[11px] text-app-fg-muted transition hover:text-app-fg"
                     >
                       Re-open
                     </button>
                   )}
                 </div>
-              </div>
+              </Card>
             ))}
           </div>
         )}
-      </div>
-    </div>
+      </Container>
+    </Shell>
   );
 }

--- a/src/app/project/[id]/search/page.tsx
+++ b/src/app/project/[id]/search/page.tsx
@@ -3,7 +3,7 @@
 import { useRef, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { AppHeader } from '@/components/layout/app-header';
-import { AppBackLink, Card, Container, PrimaryButton, Shell, TextInput } from '@/components/ui/primitives';
+import { AppBackLink, Card, Container, PrimaryButton, Shell, StatusMessage, TextInput } from '@/components/ui/primitives';
 import { requestJson } from '@/lib/client/request';
 
 type SearchResponse = {
@@ -69,7 +69,7 @@ export default function SearchPage() {
           <PrimaryButton onClick={runSearch} disabled={searching}>
             {searching ? 'Searching...' : 'Search'}
           </PrimaryButton>
-          {error && <p className="text-sm text-red-300">{error}</p>}
+          {error && <StatusMessage state="error" title={error} />}
         </Card>
 
         <div className="mt-4 space-y-2">

--- a/src/components/project/dashboard/dashboard-action-cards.tsx
+++ b/src/components/project/dashboard/dashboard-action-cards.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { GlassCard } from '@/components/ui/primitives';
 
 export function DashboardActionCards({
   id,
@@ -9,40 +10,28 @@ export function DashboardActionCards({
   documentCount: number;
   sessionCount: number;
 }) {
+  const cards = [
+    { href: `/project/${id}/record`, icon: '🎙️', label: 'Record', detail: 'Voice session', featured: true },
+    { href: `/project/${id}/documents`, icon: '📄', label: 'Documents', detail: `${documentCount} ${documentCount === 1 ? 'doc' : 'docs'}` },
+    { href: `/project/${id}/sessions`, icon: '📼', label: 'Sessions', detail: `${sessionCount} ${sessionCount === 1 ? 'session' : 'sessions'}` },
+    { href: `/project/${id}/export`, icon: '📤', label: 'Export', detail: 'Export work' },
+  ];
+
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
-      <Link
-        href={`/project/${id}/record`}
-        className="bg-indigo-600 hover:bg-indigo-700 rounded-xl p-5 text-center transition-colors"
-      >
-        <div className="text-3xl mb-2">🎙️</div>
-        <div className="font-semibold">Record</div>
-        <div className="text-indigo-300 text-xs mt-1">Voice session</div>
-      </Link>
-      <Link
-        href={`/project/${id}/documents`}
-        className="bg-gray-800 hover:bg-gray-700 rounded-xl p-5 text-center transition-colors"
-      >
-        <div className="text-3xl mb-2">📄</div>
-        <div className="font-semibold">Documents</div>
-        <div className="text-gray-400 text-xs mt-1">{documentCount} {documentCount === 1 ? 'doc' : 'docs'}</div>
-      </Link>
-      <Link
-        href={`/project/${id}/sessions`}
-        className="bg-gray-800 hover:bg-gray-700 rounded-xl p-5 text-center transition-colors"
-      >
-        <div className="text-3xl mb-2">📼</div>
-        <div className="font-semibold">Sessions</div>
-        <div className="text-gray-400 text-xs mt-1">{sessionCount} {sessionCount === 1 ? 'session' : 'sessions'}</div>
-      </Link>
-      <Link
-        href={`/project/${id}/export`}
-        className="bg-gray-800 hover:bg-gray-700 rounded-xl p-5 text-center transition-colors"
-      >
-        <div className="text-3xl mb-2">📤</div>
-        <div className="font-semibold">Export</div>
-        <div className="text-gray-400 text-xs mt-1">Export work</div>
-      </Link>
+    <div className="mb-8 grid grid-cols-2 gap-4 md:grid-cols-4">
+      {cards.map((card) => (
+        <Link key={card.href} href={card.href} className="group block">
+          <GlassCard
+            className={`h-full p-5 text-center transition group-hover:border-neon-lime/40 ${
+              card.featured ? 'border-neon-lime/30 bg-neon-lime-dim' : ''
+            }`}
+          >
+            <div className="mb-2 text-3xl">{card.icon}</div>
+            <div className="font-semibold text-app-fg">{card.label}</div>
+            <div className="mt-1 text-xs text-app-fg-muted">{card.detail}</div>
+          </GlassCard>
+        </Link>
+      ))}
     </div>
   );
 }

--- a/src/components/project/dashboard/dashboard-insights-grid.tsx
+++ b/src/components/project/dashboard/dashboard-insights-grid.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { Card } from '@/components/ui/primitives';
 import { DashboardInsightsProps } from '@/components/project/dashboard/types';
 
 export function DashboardInsightsGrid({
@@ -10,107 +11,105 @@ export function DashboardInsightsGrid({
   onResolveGap,
 }: DashboardInsightsProps) {
   return (
-    <div className="grid md:grid-cols-3 gap-6">
-      <div className="bg-gray-900 border border-gray-700 rounded-xl p-5">
-        <div className="flex items-center gap-2 mb-4">
+    <div className="grid gap-6 md:grid-cols-3">
+      <Card>
+        <div className="mb-4 flex items-center gap-2">
           <span className="text-xl">🧵</span>
-          <h2 className="font-semibold text-white">Dropped Threads</h2>
+          <h2 className="font-semibold text-app-fg">Dropped Threads</h2>
           {pendingTangents.length > 0 && (
-            <span className="bg-amber-500 text-black text-xs font-bold px-2 py-0.5 rounded-full ml-auto">
+            <span className="ml-auto rounded-full border border-neon-purple-border bg-neon-purple-dim px-2 py-0.5 text-xs font-bold text-neon-purple">
               {pendingTangents.length}
             </span>
           )}
         </div>
         {pendingTangents.length === 0 ? (
-          <p className="text-gray-500 text-sm">No dropped threads yet.</p>
+          <p className="text-sm text-app-fg-muted">No dropped threads yet.</p>
         ) : (
           <div className="space-y-3">
             {pendingTangents.slice(0, 5).map((tangent) => (
-              <div key={tangent.id} className="bg-gray-800 rounded-lg p-3">
-                <p className="text-sm text-amber-400 font-medium">{tangent.thread}</p>
+              <div key={tangent.id} className="rounded-xl border border-app-border bg-app-surface-muted p-3">
+                <p className="text-sm font-medium text-neon-purple">{tangent.thread}</p>
                 {tangent.context && (
-                  <p className="text-xs text-gray-500 mt-1 italic">&quot;{tangent.context}&quot;</p>
-                )}
-                <div className="flex gap-2 mt-2">
-                  <button
-                    onClick={() => onResolveTangent(tangent.id)}
-                    className="text-xs text-green-400 hover:text-green-300"
-                  >
-                    ✓ Resolved
-                  </button>
-                </div>
-              </div>
-            ))}
-            <Link href={`/project/${id}/tangents`} className="text-xs text-indigo-400 hover:text-indigo-300">
-              View all tangents →
-            </Link>
-          </div>
-        )}
-      </div>
-
-      <div className="bg-gray-900 border border-gray-700 rounded-xl p-5">
-        <div className="flex items-center gap-2 mb-4">
-          <span className="text-xl">🔍</span>
-          <h2 className="font-semibold text-white">Gaps</h2>
-          {openGaps.length > 0 && (
-            <span className="bg-red-500 text-white text-xs font-bold px-2 py-0.5 rounded-full ml-auto">
-              {openGaps.length}
-            </span>
-          )}
-        </div>
-        {openGaps.length === 0 ? (
-          <p className="text-gray-500 text-sm">No gaps detected yet. Add more sessions.</p>
-        ) : (
-          <div className="space-y-3">
-            {openGaps.slice(0, 5).map((gap) => (
-              <div key={gap.id} className="bg-gray-800 rounded-lg p-3">
-                <p className="text-sm text-red-400">{gap.description}</p>
-                {gap.documentRef && (
-                  <p className="text-xs text-gray-500 mt-1">In: {gap.documentRef}</p>
+                  <p className="mt-1 text-xs italic text-app-fg-muted">&quot;{tangent.context}&quot;</p>
                 )}
                 <button
-                  onClick={() => onResolveGap(gap.id)}
-                  className="text-xs text-green-400 hover:text-green-300 mt-2"
+                  onClick={() => onResolveTangent(tangent.id)}
+                  className="mt-2 text-xs text-neon-lime transition hover:text-neon-lime/80"
                 >
                   ✓ Resolved
                 </button>
               </div>
             ))}
-            <Link href={`/project/${id}/gaps`} className="text-xs text-indigo-400 hover:text-indigo-300">
+            <Link href={`/project/${id}/tangents`} className="text-xs text-neon-lime transition hover:text-neon-lime/80">
+              View all tangents →
+            </Link>
+          </div>
+        )}
+      </Card>
+
+      <Card>
+        <div className="mb-4 flex items-center gap-2">
+          <span className="text-xl">🔍</span>
+          <h2 className="font-semibold text-app-fg">Gaps</h2>
+          {openGaps.length > 0 && (
+            <span className="ml-auto rounded-full border border-neon-pink-border bg-neon-pink-dim px-2 py-0.5 text-xs font-bold text-neon-pink">
+              {openGaps.length}
+            </span>
+          )}
+        </div>
+        {openGaps.length === 0 ? (
+          <p className="text-sm text-app-fg-muted">No gaps detected yet. Add more sessions.</p>
+        ) : (
+          <div className="space-y-3">
+            {openGaps.slice(0, 5).map((gap) => (
+              <div key={gap.id} className="rounded-xl border border-app-border bg-app-surface-muted p-3">
+                <p className="text-sm text-neon-pink">{gap.description}</p>
+                {gap.documentRef && (
+                  <p className="mt-1 text-xs text-app-fg-muted">In: {gap.documentRef}</p>
+                )}
+                <button
+                  onClick={() => onResolveGap(gap.id)}
+                  className="mt-2 text-xs text-neon-lime transition hover:text-neon-lime/80"
+                >
+                  ✓ Resolved
+                </button>
+              </div>
+            ))}
+            <Link href={`/project/${id}/gaps`} className="text-xs text-neon-lime transition hover:text-neon-lime/80">
               View all gaps →
             </Link>
           </div>
         )}
-      </div>
+      </Card>
 
-      <div className="bg-gray-900 border border-gray-700 rounded-xl p-5">
-        <div className="flex items-center gap-2 mb-4">
+      <Card>
+        <div className="mb-4 flex items-center gap-2">
           <span className="text-xl">🔁</span>
-          <h2 className="font-semibold text-white">Patterns</h2>
+          <h2 className="font-semibold text-app-fg">Patterns</h2>
           {newPatterns.length > 0 && (
-            <span className="bg-purple-500 text-white text-xs font-bold px-2 py-0.5 rounded-full ml-auto">
+            <span className="ml-auto rounded-full border border-neon-lime-border bg-neon-lime-dim px-2 py-0.5 text-xs font-bold text-neon-lime">
               {newPatterns.length}
             </span>
           )}
         </div>
         {newPatterns.length === 0 ? (
-          <p className="text-gray-500 text-sm">No patterns detected yet.</p>
+          <p className="text-sm text-app-fg-muted">No patterns detected yet.</p>
         ) : (
           <div className="space-y-3">
             {newPatterns.slice(0, 5).map((pattern) => (
-              <div key={pattern.id} className="bg-gray-800 rounded-lg p-3">
-                <p className="text-sm text-purple-400">{pattern.description}</p>
-                <p className="text-xs text-gray-500 mt-1">
+              <div key={pattern.id} className="rounded-xl border border-app-border bg-app-surface-muted p-3">
+                <p className="text-sm text-neon-lime">{pattern.description}</p>
+                <p className="mt-1 text-xs text-app-fg-muted">
                   {pattern.sessionRefs.length} {pattern.sessionRefs.length === 1 ? 'session' : 'sessions'}
                 </p>
               </div>
             ))}
-            <Link href={`/project/${id}/patterns`} className="text-xs text-indigo-400 hover:text-indigo-300">
+            <Link href={`/project/${id}/patterns`} className="text-xs text-neon-lime transition hover:text-neon-lime/80">
               View all patterns →
             </Link>
           </div>
         )}
-      </div>
+      </Card>
     </div>
   );
 }

--- a/src/components/project/dashboard/dashboard-questions-card.tsx
+++ b/src/components/project/dashboard/dashboard-questions-card.tsx
@@ -1,19 +1,20 @@
 import Link from 'next/link';
+import { Card } from '@/components/ui/primitives';
 
 export function DashboardQuestionsCard({ id, pendingQuestionsCount }: { id: string; pendingQuestionsCount: number }) {
   return (
-    <div className="mt-6 bg-gray-900 border border-gray-700 rounded-xl p-5">
-      <div className="flex items-center gap-2 mb-4">
+    <Card className="mt-6">
+      <div className="mb-4 flex items-center gap-2">
         <span className="text-xl">❓</span>
-        <h2 className="font-semibold text-white">Questions for You</h2>
+        <h2 className="font-semibold text-app-fg">Questions for You</h2>
       </div>
       <Link
         href={`/project/${id}/questions`}
-        className="text-indigo-400 hover:text-indigo-300 text-sm"
+        className="text-sm text-neon-lime transition hover:text-neon-lime/80"
       >
         View all questions →
       </Link>
-      <p className="text-gray-500 text-xs mt-2">{pendingQuestionsCount} pending</p>
-    </div>
+      <p className="mt-2 text-xs text-app-fg-muted">{pendingQuestionsCount} pending</p>
+    </Card>
   );
 }

--- a/src/components/project/dashboard/dashboard-search-card.tsx
+++ b/src/components/project/dashboard/dashboard-search-card.tsx
@@ -1,4 +1,5 @@
 import { ProjectSearchResult } from '@/components/project/dashboard/types';
+import { Card, PrimaryButton, TextInput } from '@/components/ui/primitives';
 
 export function DashboardSearchCard({
   searchTerm,
@@ -14,13 +15,13 @@ export function DashboardSearchCard({
   onSearch: () => Promise<void>;
 }) {
   return (
-    <div className="mt-6 bg-gray-900 border border-gray-700 rounded-xl p-5">
-      <div className="flex items-center gap-2 mb-3">
+    <Card className="mt-6">
+      <div className="mb-3 flex items-center gap-2">
         <span className="text-xl">🔎</span>
-        <h2 className="font-semibold text-white">Search Across Everything</h2>
+        <h2 className="font-semibold text-app-fg">Search Across Everything</h2>
       </div>
-      <div className="flex gap-2">
-        <input
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <TextInput
           type="text"
           value={searchTerm}
           onChange={(e) => onSearchTermChange(e.target.value)}
@@ -29,28 +30,28 @@ export function DashboardSearchCard({
           aria-label="Search project content"
           aria-busy={searching}
           placeholder="Search sessions, docs, concepts, questions..."
-          className="flex-1 bg-gray-800 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500"
+          className="flex-1"
         />
-        <button
+        <PrimaryButton
           onClick={onSearch}
           disabled={searching}
           aria-busy={searching}
-          className="rounded bg-indigo-600 px-4 py-2 text-sm text-white disabled:cursor-not-allowed disabled:opacity-60 hover:bg-indigo-700"
+          className="disabled:cursor-not-allowed"
         >
           {searching ? 'Searching...' : 'Search'}
-        </button>
+        </PrimaryButton>
       </div>
       {searchResults.length > 0 && (
         <div className="mt-3 space-y-2">
           {searchResults.slice(0, 10).map((r) => (
-            <div key={`${r.kind}:${r.id}`} className="bg-gray-800 rounded p-3">
-              <p className="text-xs text-gray-500 uppercase">{r.kind}</p>
-              <p className="text-sm text-gray-200">{r.title}</p>
-              {r.snippet && <p className="text-xs text-gray-400 mt-1">{r.snippet}</p>}
+            <div key={`${r.kind}:${r.id}`} className="rounded-xl border border-app-border bg-app-surface-muted p-3">
+              <p className="text-xs uppercase text-app-fg-muted">{r.kind}</p>
+              <p className="text-sm text-app-fg">{r.title}</p>
+              {r.snippet && <p className="mt-1 text-xs text-app-fg-muted">{r.snippet}</p>}
             </div>
           ))}
         </div>
       )}
-    </div>
+    </Card>
   );
 }

--- a/src/components/project/insights-page.tsx
+++ b/src/components/project/insights-page.tsx
@@ -69,7 +69,7 @@ export function ProjectInsightsPage<TItem>({
         )}
 
         <div className="mt-6">
-          <Link href={`/project/${id}/record`} className="text-sm text-indigo-400 hover:text-indigo-300">
+          <Link href={`/project/${id}/record`} className="text-sm text-neon-lime transition hover:text-neon-lime/80">
             Record a new session →
           </Link>
         </div>


### PR DESCRIPTION
### Motivation
- Replace one-off page shells and ad-hoc gray/indigo styling with shared UI primitives to standardize layout and visual tokens across project pages and dashboard cards.
- Preserve existing data flows, routes, and API contracts while moving to the app-level CSS variables and components.

### Description
- Converted project pages to use `Shell`, `Container`, `AppBackLink`, `AppHeader`, `Card`/`GlassCard`, `PrimaryButton`, `SecondaryButton`, `TextInput`, `TextArea`, and `StatusMessage` from `src/components/ui/primitives.tsx`.
- Reworked dashboard cards and insights components to use `Card`/`GlassCard` and app CSS token classes instead of one-off utility colors, and improved responsive composition (mobile → tablet → desktop) without changing behavior.
- Preserved all existing data fetching, request payloads, response handling, and link/route paths so no API or Prisma changes were made.
- Changed files: `src/app/project/[id]/documents/page.tsx`, `src/app/project/[id]/questions/page.tsx`, `src/app/project/[id]/search/page.tsx`, `src/app/project/[id]/page.tsx`, `src/components/project/insights-page.tsx`, `src/components/project/dashboard/dashboard-action-cards.tsx`, `src/components/project/dashboard/dashboard-insights-grid.tsx`, `src/components/project/dashboard/dashboard-questions-card.tsx`, and `src/components/project/dashboard/dashboard-search-card.tsx`.

### Testing
- Ran `npm run lint` and it passed with no ESLint warnings or errors.
- Ran `npm run build` and the project built successfully; build logs include the expected `OPENAI_API_KEY` warning but completed normally.
- Ran `npx tsc --noEmit` which reported pre-existing unrelated test/mock type errors in server-side tests (these failures are outside the UI changes in this PR).
- Ran `git diff --check` and found no whitespace or diff errors; manual inspection of responsive class usage was done for mobile/tablet/desktop.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b714aa73c83209b39109a041c4ce6)